### PR TITLE
Fix login user data storage bug

### DIFF
--- a/eventim-disability-integration/src/pages/login.jsx
+++ b/eventim-disability-integration/src/pages/login.jsx
@@ -44,13 +44,16 @@ export default function LoginPage() {
 
             const data = await res.json();
             if (res.ok) {
+                // The API already returns camelCase properties, but we were
+                // incorrectly using the snake_case variants here. This caused
+                // `useAuth` to read `undefined` values from localStorage.
                 localStorage.setItem(
                     'user',
                     JSON.stringify({
-                          userId: data.user.user_id,
-                          email: data.user.email,
-                          firstName: data.user.first_name,
-                        lastName: data.user.last_name,
+                        userId:    data.user.userId,
+                        email:     data.user.email,
+                        firstName: data.user.firstName,
+                        lastName:  data.user.lastName,
                     })
                 );
                 router.push('/').then(() => window.location.reload());


### PR DESCRIPTION
## Summary
- ensure login page stores API user data using camelCase keys

## Testing
- `npm test --silent` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe95ae3308330ad40ed7d1bc7ca6d