### PR TITLE
Update venue and event creation for areas

### DIFF
--- a/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
@@ -15,6 +15,8 @@ export default function EventCreation() {
     const [venues, setVenues] = useState([]);
     const [artists, setArtists] = useState([]);
     const [eventArtists, setEventArtists] = useState([]); // [{ artistId, role }]
+    const [venueAreas, setVenueAreas] = useState([]); // fetched based on venue
+    const [categories, setCategories] = useState([]); // [{ name, price, areaId, capacity }]
     const [message, setMessage] = useState('');
     const [loading, setLoading] = useState(false);
 
@@ -26,6 +28,20 @@ export default function EventCreation() {
         fetch('http://localhost:4000/artists')
             .then(r => r.json()).then(d => setArtists(d.artists));
     }, []);
+
+    useEffect(() => {
+        if (!formData.venueId) {
+            setVenueAreas([]);
+            return;
+        }
+        fetch(`http://localhost:4000/venue-areas?venueId=${formData.venueId}`)
+            .then(r => r.json())
+            .then(d => setVenueAreas(d.venueAreas || []))
+            .catch(err => {
+                console.error('Error loading venue areas', err);
+                setVenueAreas([]);
+            });
+    }, [formData.venueId]);
 
     const handleChange = e => {
         const { name, value } = e.target;
@@ -42,6 +58,17 @@ export default function EventCreation() {
         setEventArtists(ea => ea.filter((_,idx)=>idx!==i));
     };
 
+    const addCategory = () => {
+        const idx = categories.length + 1;
+        setCategories(c => [...c, { name: `Kategorie ${idx}`, price: '', areaId: '', capacity: '' }]);
+    };
+    const updateCategory = (i, field, val) => {
+        setCategories(c => c.map((it, idx) => idx===i ? { ...it, [field]: val } : it));
+    };
+    const removeCategory = i => {
+        setCategories(c => c.filter((_,idx)=>idx!==i));
+    };
+
     const handleSubmit = async e => {
         e.preventDefault();
         setLoading(true);
@@ -52,8 +79,15 @@ export default function EventCreation() {
             setLoading(false);
             return;
         }
+        for (const cat of categories) {
+            if (!cat.areaId || !cat.capacity || !cat.price) {
+                setMessage('Alle Kategorien benötigen Bereich, Kapazität und Preis');
+                setLoading(false);
+                return;
+            }
+        }
         try {
-            const payload = { ...formData, eventArtists };
+            const payload = { ...formData, eventArtists, categories };
             const res = await fetch('http://localhost:4000/create-event', {
                 method:'POST',
                 headers:{ 'Content-Type':'application/json' },
@@ -64,6 +98,7 @@ export default function EventCreation() {
                 setMessage(`Event erstellt`);
                 setFormData({ tourId:'', venueId:'', doorTime:'', startTime:'', endTime:'', description:'' });
                 setEventArtists([]);
+                setCategories([]);
             } else {
                 setMessage(data.message||'Fehler beim Erstellen');
             }
@@ -154,6 +189,35 @@ export default function EventCreation() {
                         + Künstler hinzufügen
                     </button>
                 </div>
+
+                {/* Kategorien */}
+                <div style={{ marginBottom:'1rem' }}>
+                    <label style={{ display:'block', fontWeight:'bold', marginBottom:'.5rem' }}>Kategorien</label>
+                    {categories.map((c,i)=>(
+                        <div key={i} style={{ marginBottom:'1rem', padding:'1rem', border:'1px solid #ddd', borderRadius:'4px' }}>
+                            <div style={{ display:'flex', justifyContent:'space-between', marginBottom:'0.5rem' }}>
+                                <strong>Kategorie {i+1}</strong>
+                                <button type="button" onClick={()=>removeCategory(i)} style={{ background:'transparent',border:'none',color:'#c00',fontSize:'1.25rem' }}>✕</button>
+                            </div>
+                            <input type="text" value={c.name} onChange={e=>updateCategory(i,'name',e.target.value)}
+                                   style={{ width:'100%', padding:'.5rem', border:'1px solid #ccc', borderRadius:'4px', marginBottom:'0.5rem' }}/>
+                            <input type="number" min="0" placeholder="Preis" value={c.price}
+                                   onChange={e=>updateCategory(i,'price',e.target.value)}
+                                   style={{ width:'100%', padding:'.5rem', border:'1px solid #ccc', borderRadius:'4px', marginBottom:'0.5rem' }}/>
+                            <select value={c.areaId} onChange={e=>updateCategory(i,'areaId',e.target.value)}
+                                    required style={{ width:'100%', padding:'.5rem', border:'1px solid #ccc', borderRadius:'4px', marginBottom:'0.5rem' }}>
+                                <option value="">Bereich wählen</option>
+                                {venueAreas.map(va=> (
+                                    <option key={va.id} value={va.id}>{va.name} (max {va.max_capacity})</option>
+                                ))}
+                            </select>
+                            <input type="number" min="0" placeholder="Kapazität" value={c.capacity}
+                                   onChange={e=>updateCategory(i,'capacity',e.target.value)}
+                                   style={{ width:'100%', padding:'.5rem', border:'1px solid #ccc', borderRadius:'4px' }}/>
+                        </div>
+                    ))}
+                    <button type="button" onClick={addCategory} style={{ background:'#eee',border:'1px solid #ccc',padding:'.5rem',borderRadius:'4px' }}>+ Kategorie hinzufügen</button>
+                </div>
                 {/* Submit */}
                 <button type="submit" disabled={loading}
                         style={{ backgroundColor:'#002b55',color:'white',padding:'0.75rem 1.5rem',
@@ -163,9 +227,4 @@ export default function EventCreation() {
             </form>
         </div>
     );
-}
-
-// Hilfsfunktionen
-function updateArtist(i, field, val) {
-    // Diese Funktion inside-Komponente definieren oder useCallback nutzen
 }


### PR DESCRIPTION
## Summary
- adjust server routes for areas and new venue/event workflow
- update venue creation page to use areas instead of total capacity
- enhance event creation to configure categories per venue area

## Testing
- `npm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403a1b49f08330a027924f7538639a