### PR TITLE
Improve database connection handling

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -2,7 +2,7 @@ const express = require('express');
 const session = require('express-session');
 const cors = require('cors');
 const path = require('path');
-const { Client } = require('pg');
+const { Pool } = require('pg');
 const bcrypt = require('bcrypt');
 const multer = require('multer');
 const crypto = require('crypto');
@@ -1761,7 +1761,17 @@ app.get('/event-accessibility', async (req, res) => {
 });
 
 
-const client = new Client(credentials);
-client.connect();
+const client = new Pool(credentials);
+client.on('error', (err) => {
+    console.error('Unexpected database error:', err);
+});
+
+process.on('unhandledRejection', (reason) => {
+    console.error('Unhandled rejection:', reason);
+});
+
+process.on('uncaughtException', (err) => {
+    console.error('Uncaught exception:', err);
+});
 
 app.listen(4000, () => console.log('Server on port 4000'));


### PR DESCRIPTION
## Summary
- use `pg.Pool` instead of single client
- log unexpected database errors
- add global handlers for unhandled rejections and uncaught exceptions

## Testing
- `node --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d945674c8330be3b12575a95f8bd