### PR TITLE
Implement dynamic event page

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -1766,6 +1766,57 @@ app.get('/event-accessibility', async (req, res) => {
     }
 });
 
+// Liefert Detailinformationen zu einem Event inklusive Kategorien und zugehörigen Künstler-IDs
+app.get('/event-details/:id', async (req, res) => {
+    const eventId = req.params.id;
+    try {
+        const { rows } = await client.query(
+            `SELECT
+                e.id,
+                e.tour_id,
+                e.venue_id,
+                e.description,
+                e.start_time,
+                e.end_time,
+                e.door_time,
+                v.name  AS "venueName",
+                c.name  AS "cityName",
+                t.title AS "tourTitle",
+                t.tour_image AS "tourImage"
+             FROM events e
+                JOIN tours t   ON t.id = e.tour_id
+                JOIN venues v  ON v.id = e.venue_id
+                JOIN cities c  ON c.id = v.city_id
+             WHERE e.id = $1`,
+            [eventId]
+        );
+
+        if (rows.length === 0) {
+            return res.status(404).json({ message: 'Event nicht gefunden' });
+        }
+        const event = rows[0];
+
+        const { rows: artistRows } = await client.query(
+            'SELECT artist_id FROM tour_artists WHERE tour_id = $1',
+            [event.tour_id]
+        );
+        const artistIds = artistRows.map((r) => r.artist_id);
+
+        const { rows: catRows } = await client.query(
+            `SELECT id, name, price, disability_support_for
+             FROM event_categories
+             WHERE event_id = $1
+             ORDER BY name`,
+            [eventId]
+        );
+
+        return res.status(200).json({ event, categories: catRows, artistIds });
+    } catch (err) {
+        console.error('Error in /event-details:', err);
+        return res.status(500).json({ message: 'Fehler beim Laden des Events' });
+    }
+});
+
 
 const client = new Client(credentials);
 client.connect()

--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
@@ -1,56 +1,88 @@
-import React, { useState } from 'react';
-
-const sampleEvent = {
-    title: 'AB/CD',
-    date: 'Samstag, 27.09.2025',
-    time: '20:30',
-    location: 'KAISERSLAUTERN',
-    venue: 'Irish House',
-    imageUrl: '/pictures/sample-event.jpg',
-    categories: [
-        {
-            id: 1,
-            name: 'Kategorie 1',
-            description: 'Eintrittskarte',
-            type: 'Normalpreis',
-            price: 23.69,
-        },
-        {
-            id: 2,
-            name: 'Kategorie 2',
-            description: 'Eintrittskarte',
-            type: 'Normalpreis',
-            price: 28.50,
-        },
-        // …add more if you need
-    ],
-};
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { API_BASE_URL } from '../../../../config';
 
 export default function EventPage() {
-    const [qty, setQty] = useState(1);
-    const [selectedCat, setSelectedCat] = useState(sampleEvent.categories[0].id);
+    const router = useRouter();
+    const { artist, tour, event } = router.query;
 
-    const currentCat = sampleEvent.categories.find(c => c.id === selectedCat);
-    const total = (qty * currentCat.price).toFixed(2).replace('.', ',');
+    const [eventData, setEventData] = useState(null);
+    const [categories, setCategories] = useState([]);
+    const [error, setError] = useState('');
+    const [loading, setLoading] = useState(true);
+
+    const [qty, setQty] = useState(1);
+    const [selectedCat, setSelectedCat] = useState(null);
+
+    useEffect(() => {
+        if (!artist || !tour || !event) return;
+        const load = async () => {
+            try {
+                const res = await fetch(`${API_BASE_URL}/event-details/${event}`);
+                if (!res.ok) throw new Error('Fetch failed');
+                const data = await res.json();
+
+                if (data.event.tour_id !== tour || !(data.artistIds || []).includes(artist)) {
+                    setError('Event passt nicht zur Tour oder zum Künstler');
+                    setLoading(false);
+                    return;
+                }
+
+                setEventData(data.event);
+                setCategories(data.categories || []);
+                setSelectedCat(data.categories && data.categories[0] ? data.categories[0].id : null);
+                setLoading(false);
+            } catch (err) {
+                console.error(err);
+                setError('Fehler beim Laden des Events');
+                setLoading(false);
+            }
+        };
+        load();
+    }, [artist, tour, event]);
+
+    const currentCat = categories.find((c) => c.id === selectedCat) || {};
+    const total = (qty * (currentCat.price || 0)).toFixed(2).replace('.', ',');
+
+    if (loading) return <div>Loading …</div>;
+    if (error) return <div>{error}</div>;
+    if (!eventData) return <div>Event nicht gefunden</div>;
+
+    const formatDate = (d) =>
+        new Date(d).toLocaleDateString('de-DE', {
+            weekday: 'long',
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+        });
+    const formatTime = (d) =>
+        new Date(d).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
 
     return (
         <div className="event-container">
             {/* ————— HEADER ————— */}
             <header className="event-header">
                 <div className="header-info">
-                    <h1 className="event-title">{sampleEvent.title}</h1>
+                    <h1 className="event-title">{eventData.tourTitle}</h1>
                     <div className="event-meta">
                         <div className="meta-item">
-                            <span className="icon-calendar" /> {sampleEvent.date} | {sampleEvent.time}
+                            <span className="icon-calendar" /> {formatDate(eventData.start_time)} | {formatTime(eventData.start_time)}
                         </div>
                         <div className="meta-item">
-                            <span className="icon-location" /> {sampleEvent.location} |{' '}
-                            <a href="#" className="venue-link">{sampleEvent.venue}</a>
+                            <span className="icon-location" /> {eventData.cityName} |{' '}
+                            <a href="#" className="venue-link">{eventData.venueName}</a>
                         </div>
                     </div>
                 </div>
                 <div className="event-hero">
-                    <img src={sampleEvent.imageUrl} alt={sampleEvent.title} />
+                    <img
+                        src={
+                            eventData.tourImage
+                                ? `${API_BASE_URL}/image/${eventData.tourImage}`
+                                : '/placeholder-tour.png'
+                        }
+                        alt={eventData.tourTitle || 'Event'}
+                    />
                 </div>
             </header>
 
@@ -61,9 +93,9 @@ export default function EventPage() {
                     <div className="card-row">
                         <div className="row-label">1. Bitte wähle die Anzahl der Tickets:</div>
                         <div className="row-control">
-                            <button onClick={() => setQty(q => Math.max(1, q - 1))}>−</button>
+                            <button onClick={() => setQty((q) => Math.max(1, q - 1))}>−</button>
                             <span className="qty-value">{qty}</span>
-                            <button onClick={() => setQty(q => q + 1)}>+</button>
+                            <button onClick={() => setQty((q) => q + 1)}>+</button>
                         </div>
                     </div>
 
@@ -73,7 +105,7 @@ export default function EventPage() {
                     </div>
 
                     {/* Kategorien */}
-                    {sampleEvent.categories.map(cat => (
+                    {categories.map((cat) => (
                         <div
                             key={cat.id}
                             className={`category-item${selectedCat === cat.id ? ' selected' : ''}`}
@@ -81,9 +113,9 @@ export default function EventPage() {
                         >
                             <div className="col name">
                                 <div className="cat-name">{cat.name}</div>
-                                <div className="cat-desc">{cat.description}</div>
+                                <div className="cat-desc" />
                             </div>
-                            <div className="col type">{cat.type}</div>
+                            <div className="col type">{cat.disability_support_for || 'Normalpreis'}</div>
                             <div className="col price">
                                 <span>€ {cat.price.toFixed(2).replace('.', ',')}</span>
                                 <input
@@ -106,7 +138,8 @@ export default function EventPage() {
                     {/* Note */}
                     <div className="note">
                         Angezeigte Preise inkl. der gesetzl. MwSt., Vorverkaufsgebühr,
-                        <a href="#"> Buchungsgebühr von max. € 0,00</a><br/>
+                        <a href="#"> Buchungsgebühr von max. € 0,00</a>
+                        <br />
                         zzgl. <a href="#">Versandkosten</a>.
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- add Express endpoint `/event-details/:id` for fetching full event info
- connect `artists/[artist]/[tour]/[event]/index.jsx` to backend API

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684abd1de8ec8330ab459caf7f2ac980