### PR TITLE
Enable redirect after login based on originating page

### DIFF
--- a/eventim-disability-integration/src/components/nav-bar.jsx
+++ b/eventim-disability-integration/src/components/nav-bar.jsx
@@ -219,7 +219,9 @@ export default function NavBar() {
                             type="button"
                             className="login-button"
                             onClick={() => {
-                                window.location.href = '/login';
+                                const current = window.location.pathname + window.location.search;
+                                const redirect = current !== '/' ? `?redirect=${encodeURIComponent(current)}` : '';
+                                window.location.href = `/login${redirect}`;
                             }}
                         >
                             Anmelden

--- a/eventim-disability-integration/src/pages/login.jsx
+++ b/eventim-disability-integration/src/pages/login.jsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 
 export default function LoginPage() {
     const router = useRouter();
+    const { redirect } = router.query;
     const [activeTab, setActiveTab] = useState('login');
 
     // Login‐Form
@@ -56,7 +57,7 @@ export default function LoginPage() {
                         lastName:  data.user.lastName,
                     })
                 );
-                router.push('/').then(() => window.location.reload());
+                router.push(redirect || '/').then(() => window.location.reload());
             } else {
                 setLoginError(data.message || 'Ungültige Anmeldedaten.');
             }


### PR DESCRIPTION
## Summary
- redirect user back to their current page after login
- extract `redirect` query parameter in the login page

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684bdd5110d883308bb2a49bb2816c18