### PR TITLE
Handle disability ticket categories

### DIFF
--- a/eventim-disability-integration/src/hooks/useAuth.js
+++ b/eventim-disability-integration/src/hooks/useAuth.js
@@ -20,10 +20,12 @@ export function useAuth() {
                     loading: false,
                     loggedIn: true,
                     user: {
-                        userId:    u.userId,
-                        email:     u.email,
-                        firstName: u.firstName,
-                        lastName:  u.lastName,
+                        userId:          u.userId,
+                        email:           u.email,
+                        firstName:       u.firstName,
+                        lastName:        u.lastName,
+                        disabilityCheck: u.disabilityCheck,
+                        disabilityMarks: u.disabilityMarks || [],
                     },
                 });
             } catch {
@@ -44,19 +46,23 @@ export function useAuth() {
                         loading: false,
                         loggedIn: true,
                         user: {
-                            userId:    data.user.userId,
-                            email:     data.user.email,
-                            firstName: data.user.firstName,
-                            lastName:  data.user.lastName,
+                            userId:          data.user.userId,
+                            email:           data.user.email,
+                            firstName:       data.user.firstName,
+                            lastName:        data.user.lastName,
+                            disabilityCheck: data.user.disabilityCheck,
+                            disabilityMarks: data.user.disabilityMarks || [],
                         },
                     });
                     localStorage.setItem(
                         'user',
                         JSON.stringify({
-                            userId:    data.user.userId,
-                            email:     data.user.email,
-                            firstName: data.user.firstName,
-                            lastName:  data.user.lastName,
+                            userId:          data.user.userId,
+                            email:           data.user.email,
+                            firstName:       data.user.firstName,
+                            lastName:        data.user.lastName,
+                            disabilityCheck: data.user.disabilityCheck,
+                            disabilityMarks: data.user.disabilityMarks || [],
                         })
                     );
                 } else {

--- a/eventim-disability-integration/src/pages/login.jsx
+++ b/eventim-disability-integration/src/pages/login.jsx
@@ -55,6 +55,8 @@ export default function LoginPage() {
                         email:     data.user.email,
                         firstName: data.user.firstName,
                         lastName:  data.user.lastName,
+                        disabilityCheck: data.user.disabilityCheck,
+                        disabilityMarks: data.user.disabilityMarks,
                     })
                 );
                 router.push(redirect || '/').then(() => window.location.reload());


### PR DESCRIPTION
## Summary
- extend login/session APIs with disability info
- persist disability status in login and auth hook
- show disability ticket options only for verified users
- filter categories to match user disability marks

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684be6433e50833086e39bbe68afd680