### PR TITLE
Preserve redirect across registration and logout

### DIFF
--- a/eventim-disability-integration/src/components/nav-bar.jsx
+++ b/eventim-disability-integration/src/components/nav-bar.jsx
@@ -199,12 +199,15 @@ export default function NavBar() {
                                     className="login-button dropdown-logout"
                                     onClick={async () => {
                                         try {
+                                            const current =
+                                                window.location.pathname +
+                                                window.location.search;
                                             await fetch(`${API_BASE_URL}/logout`, {
                                                 method: 'POST',
                                                 credentials: 'include',
                                             });
                                             localStorage.removeItem('user');
-                                            window.location.href = '/';
+                                            window.location.href = current || '/';
                                         } catch (err) {
                                             console.error('Logout fehlgeschlagen:', err);
                                         }

--- a/eventim-disability-integration/src/pages/login.jsx
+++ b/eventim-disability-integration/src/pages/login.jsx
@@ -86,7 +86,10 @@ export default function LoginPage() {
         }
         sessionStorage.setItem('preRegEmail', registerEmail.trim());
         sessionStorage.setItem('preRegPassword', registerPassword);
-        router.push('/registration');
+        const redirectParam = redirect
+            ? `?redirect=${encodeURIComponent(redirect)}`
+            : '';
+        router.push(`/registration${redirectParam}`);
     };
 
     return (

--- a/eventim-disability-integration/src/pages/registration.jsx
+++ b/eventim-disability-integration/src/pages/registration.jsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 
 export default function Registration() {
     const router = useRouter();
+    const { redirect } = router.query;
 
     const [formData, setFormData] = useState({
         firstName: '',
@@ -153,7 +154,13 @@ export default function Registration() {
 
             if (response.ok) {
                 setMessage('Registrierung erfolgreich! Weiterleitung...');
-                setTimeout(() => router.push('/login'), 2000);
+                const redirectParam = redirect
+                    ? `?redirect=${encodeURIComponent(redirect)}`
+                    : '';
+                setTimeout(
+                    () => router.push(`/login${redirectParam}`),
+                    2000
+                );
             } else {
                 setMessage(data.message || 'Registrierung fehlgeschlagen');
             }


### PR DESCRIPTION
## Summary
- keep `redirect` query when jumping from login to registration
- let registration forward the `redirect` param back to login
- after logout go back to the current page instead of the homepage

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bf25bf1a48330ae065d122ff807aa