### PR TITLE
Enforce cart limits

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -1880,7 +1880,7 @@ app.post('/cart-items', async (req, res) => {
         return res.status(401).json({ message: 'Not logged in' });
     }
 
-    const { eventId, eventCategoryId, quantity, price } = req.body;
+    let { eventId, eventCategoryId, quantity, price } = req.body;
     if (!eventId || !eventCategoryId || !quantity || !price) {
         return res.status(400).json({ message: 'Missing parameters' });
     }
@@ -1897,6 +1897,50 @@ app.post('/cart-items', async (req, res) => {
         );
         if (dup.rows.length) {
             return res.status(409).json({ message: 'Item already in cart' });
+        }
+
+        // gather category info
+        const { rows: catInfo } = await client.query(
+            'SELECT event_id, disability_support_for FROM event_categories WHERE id = $1',
+            [eventCategoryId]
+        );
+        if (catInfo.length === 0) {
+            return res.status(400).json({ message: 'Invalid category' });
+        }
+        const catEventId = catInfo[0].event_id;
+        const isDisabledCat = catInfo[0].disability_support_for !== null;
+
+        // verify eventId from body matches category's event_id
+        eventId = catEventId;
+
+        // quantity limits
+        if (isDisabledCat) {
+            // only one disabled ticket per event across all categories
+            const { rows: dRows } = await client.query(
+                `SELECT COALESCE(SUM(ci.quantity),0) AS qty
+                 FROM cart_items ci
+                         JOIN event_categories ec ON ec.id = ci.event_category_id
+                 WHERE ci.cart_id = $1 AND ec.event_id = $2 AND ec.disability_support_for IS NOT NULL`,
+                [cartId, catEventId]
+            );
+            const disabledQty = Number(dRows[0].qty) || 0;
+            if (disabledQty >= 1) {
+                return res.status(400).json({ message: 'Disabled ticket already in cart' });
+            }
+            quantity = 1; // enforce
+        } else {
+            // total regular tickets across event may not exceed 8
+            const { rows: rRows } = await client.query(
+                `SELECT COALESCE(SUM(ci.quantity),0) AS qty
+                 FROM cart_items ci
+                         JOIN event_categories ec ON ec.id = ci.event_category_id
+                 WHERE ci.cart_id = $1 AND ec.event_id = $2 AND ec.disability_support_for IS NULL`,
+                [cartId, catEventId]
+            );
+            const regularQty = Number(rRows[0].qty) || 0;
+            if (regularQty + Number(quantity) > 8) {
+                return res.status(400).json({ message: 'Regular ticket limit exceeded' });
+            }
         }
 
         // insert and return the new id & quantity
@@ -1941,8 +1985,11 @@ app.get('/cart-items', async (req, res) => {
             `
                 SELECT
                     ci.id,
-                    t.title        AS title,
-                    ec.name        AS category,
+                    ci.event_id,
+                    ec.id      AS event_category_id,
+                    ec.disability_support_for,
+                    t.title    AS title,
+                    ec.name    AS category,
                     ci.quantity,
                     ci.price
                 FROM cart_items ci
@@ -1978,6 +2025,41 @@ app.patch('/cart-items/:id', async (req, res) => {
     try {
         // ensure that this item actually belongs to user’s cart
         const cartId = await getOrCreateCart(userId);
+
+        // get item details
+        const { rows: itemRows } = await client.query(
+            `SELECT ci.quantity, ec.event_id, ec.disability_support_for
+             FROM cart_items ci
+                      JOIN event_categories ec ON ec.id = ci.event_category_id
+             WHERE ci.id = $1 AND ci.cart_id = $2`,
+            [cartItemId, cartId]
+        );
+        if (itemRows.length === 0) {
+            return res.status(404).json({ message: 'Item not found' });
+        }
+        const oldQty = itemRows[0].quantity;
+        const eventId = itemRows[0].event_id;
+        const isDisabled = itemRows[0].disability_support_for !== null;
+
+        if (isDisabled) {
+            if (quantity > 1) {
+                return res.status(400).json({ message: 'Disabled ticket limit exceeded' });
+            }
+        } else {
+            const { rows: rRows } = await client.query(
+                `SELECT COALESCE(SUM(ci.quantity),0) AS qty
+                 FROM cart_items ci
+                          JOIN event_categories ec ON ec.id = ci.event_category_id
+                 WHERE ci.cart_id = $1 AND ec.event_id = $2 AND ec.disability_support_for IS NULL`,
+                [cartId, eventId]
+            );
+            const total = Number(rRows[0].qty) || 0;
+            const newTotal = total - oldQty + quantity;
+            if (newTotal > 8) {
+                return res.status(400).json({ message: 'Regular ticket limit exceeded' });
+            }
+        }
+
         const result = await client.query(
             `UPDATE cart_items
          SET quantity = $1
@@ -1985,9 +2067,6 @@ app.patch('/cart-items/:id', async (req, res) => {
        RETURNING id, quantity`,
             [quantity, cartItemId, cartId]
         );
-        if (!result.rows.length) {
-            return res.status(404).json({ message: 'Item not found' });
-        }
         res.json(result.rows[0]);
     } catch (err) {
         console.error('Error patching cart item:', err);

--- a/eventim-disability-integration/src/hooks/useCart.js
+++ b/eventim-disability-integration/src/hooks/useCart.js
@@ -9,6 +9,7 @@ export function CartProvider({ children }) {
     const { loading: authLoading, loggedIn } = useAuth();
     const [items, setItems] = useState([]);
     const [loading, setLoading] = useState(false);
+    const [counts, setCounts] = useState({});
 
     const fetchCart = useCallback(async () => {
         if (authLoading) return;
@@ -22,11 +23,22 @@ export function CartProvider({ children }) {
             if (res.ok) {
                 const { items } = await res.json();
                 setItems(items || []);
+                const agg = {};
+                (items || []).forEach((it) => {
+                    const eid = it.event_id;
+                    const isDisabled = it.disability_support_for !== null && it.disability_support_for !== undefined;
+                    if (!agg[eid]) agg[eid] = { regular: 0, disabled: 0 };
+                    if (isDisabled) agg[eid].disabled += Number(it.quantity);
+                    else agg[eid].regular += Number(it.quantity);
+                });
+                setCounts(agg);
             } else {
                 setItems([]);
+                setCounts({});
             }
         } catch {
             setItems([]);
+            setCounts({});
         } finally {
             setLoading(false);
         }
@@ -40,7 +52,7 @@ export function CartProvider({ children }) {
     const reload = useCallback(fetchCart, [fetchCart]);
 
     return (
-        <CartContext.Provider value={{ items, loading, reload }}>
+        <CartContext.Provider value={{ items, loading, reload, counts }}>
             {children}
         </CartContext.Provider>
     );

--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
@@ -21,28 +21,25 @@ export default function EventPage() {
 
 // Track category IDs already in cart
     const [inCartItems, setInCartItems] = useState({});
-    const { reload: reloadCart } = useCart();
+    const { reload: reloadCart, items: cartItems, counts } = useCart();
 
     const [successMessage, setSuccessMessage] = useState('');
     const [errorMessage, setErrorMessage] = useState('');
     const [lastClickedSection, setLastClickedSection] = useState(null);  // 'disabled' or 'regular'
     const [addDisabled, setAddDisabled] = useState(false);
 
-// Fetch existing cart items when logged in
+// Build lookup table for items currently in cart
     useEffect(() => {
-        if (!loggedIn) return;
-        (async () => {
-            const res = await fetch(`${API_BASE_URL}/cart-items`, { credentials: 'include' });
-            if (!res.ok) return;
-            const { items } = await res.json();
-            // build a lookup by category
-            const map = {};
-            items.forEach(i => {
-                map[i.event_category_id] = { id: i.id, quantity: i.quantity };
-            });
-            setInCartItems(map);
-        })();
-    }, [loggedIn]);
+        if (!loggedIn) {
+            setInCartItems({});
+            return;
+        }
+        const map = {};
+        (cartItems || []).forEach((i) => {
+            map[i.event_category_id] = { id: i.id, quantity: i.quantity };
+        });
+        setInCartItems(map);
+    }, [loggedIn, cartItems]);
 
 
     useEffect(() => {
@@ -91,6 +88,8 @@ export default function EventPage() {
         (c) => c.disability_support_for == null
     );
 
+    const eventCounts = counts[event] || { regular: 0, disabled: 0 };
+
     useEffect(() => {
         if (categories.length === 0) return;
         const allCats = [
@@ -130,9 +129,10 @@ export default function EventPage() {
         // If regular and already in cart, PATCH new quantity
         if (existing && isRegularCatSelected) {
             const newQty = existing.quantity + qty;
-            if (newQty > 8) {
+            const newTotal = eventCounts.regular - existing.quantity + newQty;
+            if (newTotal > 8) {
                 setLastClickedSection('regular');
-                setErrorMessage(`Maximal ${8 - existing.quantity} weitere Tickets möglich.`);
+                setErrorMessage(`Maximal ${8 - (eventCounts.regular - existing.quantity)} weitere Tickets möglich.`);
                 setTimeout(() => setErrorMessage(''), 3000);
                 return;
             }
@@ -163,6 +163,18 @@ export default function EventPage() {
         }
 
         // Otherwise (new item OR disabled), do POST
+        if (isDisabledCatSelected && eventCounts.disabled >= 1) {
+            setLastClickedSection('disabled');
+            setErrorMessage('Es kann nur ein Behinderten-Ticket gebucht werden.');
+            setTimeout(() => setErrorMessage(''), 3000);
+            return;
+        }
+        if (isRegularCatSelected && eventCounts.regular + qty > 8) {
+            setLastClickedSection('regular');
+            setErrorMessage(`Maximal ${8 - eventCounts.regular} weitere Tickets möglich.`);
+            setTimeout(() => setErrorMessage(''), 3000);
+            return;
+        }
         const payload = {
             eventId: event,
             eventCategoryId: selectedCat,
@@ -319,7 +331,8 @@ export default function EventPage() {
                             className="total-button"
                             disabled={
                                 !isDisabledCatSelected ||
-                                Boolean(inCartItems[selectedCat])
+                                Boolean(inCartItems[selectedCat]) ||
+                                eventCounts.disabled >= 1
                             }
                             onClick={handleAddToCart}
                         >
@@ -358,8 +371,8 @@ export default function EventPage() {
                                     {isRegularCatSelected ? qty : 1}
                                 </span>
                             <button
-                                onClick={() => setQty((q) => Math.min(8, q + 1))}
-                                disabled={!isRegularCatSelected || qty >= 8}
+                                onClick={() => setQty((q) => Math.min(8 - eventCounts.regular, q + 1))}
+                                disabled={!isRegularCatSelected || qty >= (8 - eventCounts.regular)}
                             >+</button>
                         </div>
                     </div>
@@ -407,7 +420,7 @@ export default function EventPage() {
                         )}
                         <button
                             className="total-button"
-                            disabled={addDisabled || !isRegularCatSelected}
+                            disabled={addDisabled || !isRegularCatSelected || eventCounts.regular >= 8}
                             onClick={handleAddToCart}
                         >
                         <span className="icon-cart" />{' '}


### PR DESCRIPTION
## Summary
- enforce disabled/regular cart limits in backend
- return category details from `/cart-items`
- compute per-event counts in `useCart`
- prevent violating limits in event page

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500bf2f7e08330be099b62c2d83d2c