### PR TITLE
Fix checkout item event details

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -2214,9 +2214,10 @@ app.get('/checkout-items', async (req, res) => {
                 SELECT
                     ci.id,
                     ec.name        AS category,
-                    t.title        AS title,         -- was eventTitle
-                    v.name         AS venueName,
-                    e.start_time   AS startTime,     -- was eventTime
+                    t.title        AS "eventTitle",
+                    v.name         AS "eventVenue",
+                    e.start_time::date AS "eventDate",
+                    e.start_time::time AS "eventStartTime",
                     t.tour_image   AS image,
                     ci.quantity,
                     ci.price

--- a/eventim-disability-integration/src/pages/checkout/index.jsx
+++ b/eventim-disability-integration/src/pages/checkout/index.jsx
@@ -102,8 +102,9 @@ export default function Checkout() {
                         id,
                         category,
                         eventTitle,
-                        venueName,
-                        eventTime,
+                        eventVenue,
+                        eventDate,
+                        eventStartTime,
                         image,
                         quantity,
                         price
@@ -124,8 +125,8 @@ export default function Checkout() {
                                 />
                                 <div className="checkoutPage__item-info">
                                     <h2>{quantity} × {eventTitle} [{category}]</h2>
-                                    <p>{venueName}</p>
-                                    <p>{new Date(eventTime).toLocaleString('de-DE', {
+                                    <p>{eventVenue}</p>
+                                    <p>{new Date(`${eventDate}T${eventStartTime}`).toLocaleString('de-DE', {
                                         weekday: 'long',
                                         day: '2-digit',
                                         month: '2-digit',


### PR DESCRIPTION
## Summary
- return event details in checkout-items endpoint
- show event venue and datetime on checkout page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516281d4588330a255a3551b3ef80e