### PR TITLE
Fix date/time display in checkout

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -2213,9 +2213,11 @@ app.get('/checkout-items', async (req, res) => {
             `
                 SELECT
                     ci.id,
+                    ci.event_id   AS "eventId",
                     ec.name        AS category,
                     t.title        AS "eventTitle",
                     v.name         AS "eventVenue",
+                    e.start_time   AS "startTime",
                     e.start_time::date AS "eventDate",
                     e.start_time::time AS "eventStartTime",
                     t.tour_image   AS image,

--- a/eventim-disability-integration/src/pages/checkout/index.jsx
+++ b/eventim-disability-integration/src/pages/checkout/index.jsx
@@ -93,6 +93,16 @@ export default function Checkout() {
     // guard against undefined
     const subtotal = (items || []).reduce((sum, t) => sum + t.price * t.quantity, 0);
 
+    const formatDate = (d) =>
+        new Date(d).toLocaleDateString('de-DE', {
+            weekday: 'long',
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+        });
+    const formatTime = (d) =>
+        new Date(d).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+
     return (
         <div className="checkoutPage__container">
             <div className="checkoutPage__cart-details">
@@ -100,11 +110,11 @@ export default function Checkout() {
                 {items.map(t => {
                     const {
                         id,
+                        eventId,
+                        startTime,
                         category,
                         eventTitle,
                         eventVenue,
-                        eventDate,
-                        eventStartTime,
                         image,
                         quantity,
                         price
@@ -126,14 +136,9 @@ export default function Checkout() {
                                 <div className="checkoutPage__item-info">
                                     <h2>{quantity} × {eventTitle} [{category}]</h2>
                                     <p>{eventVenue}</p>
-                                    <p>{new Date(`${eventDate}T${eventStartTime}`).toLocaleString('de-DE', {
-                                        weekday: 'long',
-                                        day: '2-digit',
-                                        month: '2-digit',
-                                        year: 'numeric',
-                                        hour: '2-digit',
-                                        minute: '2-digit'
-                                    })}</p>
+                                    <p>
+                                        {formatDate(startTime)} | {formatTime(startTime)}
+                                    </p>
                                 </div>
                             </div>
                             <button


### PR DESCRIPTION
## Summary
- return `eventId` and `startTime` from `/checkout-items`
- format event date and time in checkout just like on event details

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518c36580c8330ae24b0166c3e2f5f