### PR TITLE
Implement shipping info page

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -330,6 +330,38 @@ app.post('/logout', (req, res) => {
         return res.status(200).json({ message: 'Erfolgreich ausgeloggt.' });
     });
 });
+
+// Liefert die in der Nutzertabelle hinterlegte Standardadresse
+app.get('/user-address', async (req, res) => {
+    if (!req.session.userId) {
+        return res.status(401).json({ message: 'Not logged in' });
+    }
+
+    try {
+        const { rows } = await client.query(
+            `SELECT salutation, first_name, last_name, company, street_address, postal_code, city, country
+             FROM users WHERE user_id = $1`,
+            [req.session.userId]
+        );
+        if (!rows.length) {
+            return res.status(404).json({ message: 'User not found' });
+        }
+        return res.json({ address: rows[0] });
+    } catch (err) {
+        console.error('Error fetching user address:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
+// Temporäres Speichern der Versandinformationen in der Session (wird später in der DB gespeichert)
+app.post('/checkout-shipping', (req, res) => {
+    if (!req.session.userId) {
+        return res.status(401).json({ message: 'Not logged in' });
+    }
+
+    req.session.shippingInfo = req.body || {};
+    return res.status(200).json({ message: 'OK' });
+});
 app.post('/create-country', async (req, res) => {
     try {
         const { name, code } = req.body;

--- a/eventim-disability-integration/src/pages/checkout/shipping-information.jsx
+++ b/eventim-disability-integration/src/pages/checkout/shipping-information.jsx
@@ -2,13 +2,45 @@
 "use client";
 
 import React, { useState, useEffect, useRef } from 'react';
+import { useRouter } from 'next/router';
 import { API_BASE_URL } from '../../config'; // adjust path if needed
 
 export default function Checkout() {
+    const router = useRouter();
     const [items, setItems] = useState([]);
     const [createdAt, setCreatedAt] = useState(null);
     const [timer, setTimer] = useState(0);
     const offsetRef = useRef(0);   // serverTime - localTime
+
+    const [useDifferentAddress, setUseDifferentAddress] = useState(false);
+    const [shippingInfo, setShippingInfo] = useState({
+        salutation: '',
+        firstName: '',
+        lastName: '',
+        company: '',
+        streetAddress: '',
+        postalCode: '',
+        city: '',
+        country: '',
+    });
+
+    const shippingOptions = [
+        { id: 'standard', label: 'Standardversand', price: 5.9 },
+        { id: 'express', label: 'Expressversand', price: 12.9 },
+    ];
+    const [selectedShipping, setSelectedShipping] = useState(shippingOptions[0]);
+
+    const fetchAddress = async () => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/user-address`, { credentials: 'include' });
+            if (res.ok) {
+                const data = await res.json();
+                if (data.address) setShippingInfo(prev => ({ ...prev, ...data.address }));
+            }
+        } catch (err) {
+            console.error('Error fetching user address:', err);
+        }
+    };
 
     // Helper: fetch checkout data
     const fetchCheckout = async () => {
@@ -39,6 +71,7 @@ export default function Checkout() {
     // 1) initial fetch + poll every 15s
     useEffect(() => {
         fetchCheckout();
+        fetchAddress();
         const poll = setInterval(fetchCheckout, 15_000);
         return () => clearInterval(poll);
     }, []);
@@ -90,8 +123,29 @@ export default function Checkout() {
         }
     };
 
+    const handleFieldChange = (e) => {
+        const { name, value } = e.target;
+        setShippingInfo(prev => ({ ...prev, [name]: value }));
+    };
+
+    const handleSubmit = async () => {
+        try {
+            await fetch(`${API_BASE_URL}/checkout-shipping`, {
+                method: 'POST',
+                credentials: 'include',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ shippingInfo, shippingMethod: selectedShipping.id })
+            });
+            router.push('/checkout/payment');
+        } catch (err) {
+            console.error('Error saving shipping info:', err);
+        }
+    };
+
     // guard against undefined
     const subtotal = (items || []).reduce((sum, t) => sum + t.price * t.quantity, 0);
+    const shippingCost = selectedShipping.price;
+    const total = subtotal + shippingCost;
 
     const formatDate = (d) =>
         new Date(d).toLocaleDateString('de-DE', {
@@ -108,18 +162,68 @@ export default function Checkout() {
             <div className="checkoutPage__item" style={{paddingLeft: '15px', minWidth: '350px'}}>
                 <div className="checkoutPage__header">Lieferinformationen</div>
                 <div className="checkoutPage__item">
-                    <div className="checkoutPage__item-header">[Checkbox] Lieferadresse weicht von persönlicher Adresse ab?</div>
-                    <div className="checkoutPage__item-info">
-                        If checkbox == true --> All fields of /pages/registration.jsx appear with the default values saved in users table
-                        if checkbox == false --> Fields do not appear
+                    <label className="checkoutPage__checkbox">
+                        <input
+                            type="checkbox"
+                            checked={useDifferentAddress}
+                            onChange={(e) => setUseDifferentAddress(e.target.checked)}
+                        />{' '}
+                        Lieferadresse weicht von persönlicher Adresse ab?
+                    </label>
+
+                    {useDifferentAddress && (
+                        <div className="shipping-form">
+                            <div className="checkoutPage__form-field">
+                                <label htmlFor="salutation">Anrede</label>
+                                <input id="salutation" name="salutation" value={shippingInfo.salutation} onChange={handleFieldChange} />
+                            </div>
+                            <div className="checkoutPage__form-field">
+                                <label htmlFor="firstName">Vorname</label>
+                                <input id="firstName" name="firstName" value={shippingInfo.firstName} onChange={handleFieldChange} />
+                            </div>
+                            <div className="checkoutPage__form-field">
+                                <label htmlFor="lastName">Nachname</label>
+                                <input id="lastName" name="lastName" value={shippingInfo.lastName} onChange={handleFieldChange} />
+                            </div>
+                            <div className="checkoutPage__form-field">
+                                <label htmlFor="company">Firma</label>
+                                <input id="company" name="company" value={shippingInfo.company} onChange={handleFieldChange} />
+                            </div>
+                            <div className="checkoutPage__form-field">
+                                <label htmlFor="streetAddress">Straße und Hausnummer</label>
+                                <input id="streetAddress" name="streetAddress" value={shippingInfo.streetAddress} onChange={handleFieldChange} />
+                            </div>
+                            <div className="checkoutPage__form-field">
+                                <label htmlFor="postalCode">PLZ</label>
+                                <input id="postalCode" name="postalCode" value={shippingInfo.postalCode} onChange={handleFieldChange} />
+                            </div>
+                            <div className="checkoutPage__form-field">
+                                <label htmlFor="city">Stadt</label>
+                                <input id="city" name="city" value={shippingInfo.city} onChange={handleFieldChange} />
+                            </div>
+                            <div className="checkoutPage__form-field">
+                                <label htmlFor="country">Land</label>
+                                <input id="country" name="country" value={shippingInfo.country} onChange={handleFieldChange} />
+                            </div>
+                        </div>
+                    )}
+
+                    <div className="checkoutPage__item-header" style={{marginTop: '1rem'}}>Versandtart</div>
+                    <div className="checkoutPage__shipping-options">
+                        {shippingOptions.map((opt) => (
+                            <label key={opt.id} className="shipping-option">
+                                <input
+                                    type="radio"
+                                    name="shippingOption"
+                                    value={opt.id}
+                                    checked={selectedShipping.id === opt.id}
+                                    onChange={() => setSelectedShipping(opt)}
+                                />{' '}
+                                {opt.label} – € {opt.price.toFixed(2)}
+                            </label>
+                        ))}
                     </div>
-                    <div className="checkoutPage__item-header">Versandtart</div>
-                    <div className="checkoutPage__item-info">
-                        Selection of dfferent versandtart options, e.g. "Standardversand", "Expressversand"
-                        (this costs should also be added to the sidebar on te right side)
-                        Standard value is "Standatdversand" with 5,90 € as Price
-                    </div>
-                    <button className="checkoutPage__checkout-button">
+                    <button className="checkoutPage__checkout-button" onClick={handleSubmit}>
                         Weiter zur Kasse
                     </button>
                 </div>
@@ -138,11 +242,15 @@ export default function Checkout() {
                             <span>€ {(t.price * t.quantity).toFixed(2)}</span>
                         </div>
                     ))}
-                    <div className="checkoutPage__order-subtotal">
-                        <span>Zwischensumme</span>
-                        <span>€ {subtotal.toFixed(2)}</span>
+                    <div className="checkoutPage__order-item">
+                        <span>Versand ({selectedShipping.label})</span>
+                        <span>€ {shippingCost.toFixed(2)}</span>
                     </div>
-                    <small>inkl. MwSt., zzgl. Versandkosten</small>
+                    <div className="checkoutPage__order-subtotal">
+                        <span>Gesamt</span>
+                        <span>€ {total.toFixed(2)}</span>
+                    </div>
+                    <small>inkl. MwSt.</small>
                 </div>
 
                 <div className="checkoutPage__payment-methods">

--- a/eventim-disability-integration/src/styles/checkout.css
+++ b/eventim-disability-integration/src/styles/checkout.css
@@ -191,3 +191,37 @@
     max-width: 60px;
     height: auto;
 }
+
+/* Shipping information form */
+.checkoutPage__checkbox {
+    display: block;
+    margin-bottom: 1rem;
+    font-size: 14px;
+}
+
+.shipping-form {
+    margin-bottom: 1rem;
+}
+
+.checkoutPage__form-field {
+    margin-bottom: 0.75rem;
+}
+
+.checkoutPage__form-field label {
+    display: block;
+    margin-bottom: 0.25rem;
+    font-weight: bold;
+}
+
+.checkoutPage__form-field input {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #D1D1D1;
+    border-radius: 4px;
+}
+
+.checkoutPage__shipping-options label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-size: 14px;
+}


### PR DESCRIPTION
## Summary
- add endpoints for user shipping address and saving shipping info in session
- implement shipping form with selectable address and shipping options
- style new shipping form elements

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b6ebf268833094576efe4911a6f6