### PR TITLE
Add DB health check with automatic reconnection

### DIFF
--- a/eventim-disability-integration/server/db.js
+++ b/eventim-disability-integration/server/db.js
@@ -1,0 +1,51 @@
+const { Pool } = require('pg');
+const credentials = require('./credentials.json');
+
+let pool = new Pool(credentials);
+
+function isConnectionError(err) {
+    return [
+        'ECONNREFUSED',
+        'ECONNRESET',
+        '57P01', // admin shutdown
+        '57P02', // crash shutdown
+        '57P03'
+    ].includes(err.code);
+}
+
+async function reconnect() {
+    try {
+        await pool.end();
+    } catch (_) {
+        // ignore errors on shutdown
+    }
+    pool = new Pool(credentials);
+}
+
+async function query(text, params) {
+    for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+            return await pool.query(text, params);
+        } catch (err) {
+            if (attempt === 0 && isConnectionError(err)) {
+                console.error('Database query failed, reconnecting...', err.message);
+                await reconnect();
+                continue;
+            }
+            throw err;
+        }
+    }
+}
+
+async function healthCheck() {
+    try {
+        await pool.query('SELECT 1');
+    } catch (err) {
+        console.error('Database health check failed, attempting reconnect...', err.message);
+        await reconnect();
+    }
+}
+
+setInterval(healthCheck, 10000);
+
+module.exports = { query };

--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -2,7 +2,8 @@ const express = require('express');
 const session = require('express-session');
 const cors = require('cors');
 const path = require('path');
-const { Client } = require('pg');
+const db = require('./db');
+const client = db;
 const bcrypt = require('bcrypt');
 const multer = require('multer');
 const crypto = require('crypto');
@@ -2349,41 +2350,47 @@ app.get(/.*/, (req, res) => {
     res.redirect(301, 'http://localhost:3000');
 });
 
-const client = new Client(credentials);
-client.connect()
-    .then(() => {
-        console.log('DB connected');
-        app.listen(4000, () => console.log('Server listening on http://localhost:4000'));
+async function startServer() {
+    while (true) {
+        try {
+            await db.query('SELECT 1');
+            console.log('DB connected');
+            break;
+        } catch (err) {
+            console.error('Failed to connect to DB, retrying in 5s...', err);
+            await new Promise(res => setTimeout(res, 5000));
+        }
+    }
 
-        // cleanup: remove expired checkouts and stale cart items every minute
-        setInterval(async () => {
-            try {
-                // drop cart items referencing removed events or categories
-                await client.query(`
-                    DELETE FROM cart_items ci
-                    WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.id = ci.event_id)
-                       OR NOT EXISTS (SELECT 1 FROM event_categories ec WHERE ec.id = ci.event_category_id)
-                `);
+    app.listen(4000, () => console.log('Server listening on http://localhost:4000'));
 
-                // delete checkout items older than 15 minutes
-                await client.query(`
-                    DELETE FROM checkout_items ci
-                    USING checkouts co
-                    WHERE ci.checkout_id = co.id
-                      AND co.created_at < NOW() - INTERVAL '15 minutes'
-                `);
+    // cleanup: remove expired checkouts and stale cart items every minute
+    setInterval(async () => {
+        try {
+            // drop cart items referencing removed events or categories
+            await db.query(`
+                DELETE FROM cart_items ci
+                WHERE NOT EXISTS (SELECT 1 FROM events e WHERE e.id = ci.event_id)
+                   OR NOT EXISTS (SELECT 1 FROM event_categories ec WHERE ec.id = ci.event_category_id)
+            `);
 
-                // delete the checkout records themselves
-                await client.query(`
-                    DELETE FROM checkouts
-                    WHERE created_at < NOW() - INTERVAL '15 minutes'
-                `);
-            } catch (err) {
-                console.error('Periodic cleanup error:', err);
-            }
-        }, 60 * 1000);
-    })
-    .catch(err => {
-        console.error('Failed to connect to DB, exiting.', err);
-        process.exit(1);
-    });
+            // delete checkout items older than 15 minutes
+            await db.query(`
+                DELETE FROM checkout_items ci
+                USING checkouts co
+                WHERE ci.checkout_id = co.id
+                  AND co.created_at < NOW() - INTERVAL '15 minutes'
+            `);
+
+            // delete the checkout records themselves
+            await db.query(`
+                DELETE FROM checkouts
+                WHERE created_at < NOW() - INTERVAL '15 minutes'
+            `);
+        } catch (err) {
+            console.error('Periodic cleanup error:', err);
+        }
+    }, 60 * 1000);
+}
+
+startServer();


### PR DESCRIPTION
## Summary
- add a dedicated DB helper with automatic reconnection
- use new helper in `server.js`
- start server after confirming DB is reachable

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npx jest` *(fails: needed to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6853dabef59083309be8d2f991c14b11