### PR TITLE
Fix shipping form defaults and add checkout session

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -360,7 +360,13 @@ app.post('/checkout-shipping', (req, res) => {
         return res.status(401).json({ message: 'Not logged in' });
     }
 
-    req.session.shippingInfo = req.body || {};
+    if (!req.session.checkout) {
+        return res.status(404).json({ message: 'No active checkout' });
+    }
+
+    const { shippingInfo, shippingMethod } = req.body || {};
+    req.session.checkout.shippingInfo = shippingInfo || {};
+    req.session.checkout.shippingMethod = shippingMethod || null;
     return res.status(200).json({ message: 'OK' });
 });
 app.post('/create-country', async (req, res) => {
@@ -2224,6 +2230,14 @@ app.post('/checkout', async (req, res) => {
         );
 
         await client.query('COMMIT');
+
+        req.session.checkout = {
+            id: checkoutId,
+            createdAt: Date.now(),
+            shippingInfo: null,
+            shippingMethod: null,
+        };
+
         return res.status(201).json({ checkoutId });
     } catch (err) {
         await client.query('ROLLBACK');
@@ -2238,6 +2252,12 @@ app.get('/checkout-items', async (req, res) => {
     const userId = req.session.userId;
     if (!userId) {
         return res.status(401).json({ message: 'Not logged in' });
+    }
+
+    const coSession = req.session.checkout;
+    if (!coSession || !coSession.createdAt || Date.now() - coSession.createdAt > 15 * 60 * 1000) {
+        req.session.checkout = null;
+        return res.status(404).json({ message: 'No active checkout' });
     }
 
     try {
@@ -2281,7 +2301,7 @@ app.get('/checkout-items', async (req, res) => {
 
         // 3) return createdAt + items array
         return res.json({
-            createdAt: created_at,
+            createdAt: new Date(coSession.createdAt).toISOString(),
             items
         });
     } catch (err) {
@@ -2309,6 +2329,7 @@ app.delete('/checkout', async (req, res) => {
         await client.query('DELETE FROM checkouts WHERE id = $1', [checkoutId]);
         await client.query('COMMIT');
 
+        req.session.checkout = null;
         return res.json({ message: 'Checkout cleared' });
     } catch (err) {
         await client.query('ROLLBACK');

--- a/eventim-disability-integration/src/pages/checkout/shipping-information.jsx
+++ b/eventim-disability-integration/src/pages/checkout/shipping-information.jsx
@@ -31,13 +31,26 @@ export default function ShippingInformation() {
     ];
     const [selectedShipping, setSelectedShipping] = useState(shippingOptions[0]);
 
-    // Fetch user data
+    // Fetch user data and map DB field names to our form fields
     const fetchAddress = async () => {
         try {
             const res = await fetch(`${API_BASE_URL}/user-address`, { credentials: 'include' });
             if (res.ok) {
                 const data = await res.json();
-                if (data.address) setShippingInfo(prev => ({ ...prev, ...data.address }));
+                if (data.address) {
+                    const a = data.address;
+                    setShippingInfo(prev => ({
+                        ...prev,
+                        salutation:    a.salutation || '',
+                        firstName:     a.first_name || '',
+                        lastName:      a.last_name || '',
+                        company:       a.company || '',
+                        streetAddress: a.street_address || '',
+                        postalCode:    a.postal_code || '',
+                        city:          a.city || '',
+                        country:       a.country || '',
+                    }));
+                }
             }
         } catch (err) {
             console.error('Error fetching user address:', err);
@@ -91,7 +104,8 @@ export default function ShippingInformation() {
     }, [createdAt]);
 
     const formatTimer = s => {
-        const m = Math.floor(s / 60), sec = s % 10 < 10 ? `0${s % 60}` : s % 60;
+        const m = Math.floor(s / 60);
+        const sec = s % 60 < 10 ? `0${s % 60}` : s % 60;
         return `${m}:${sec} Min.`;
     };
 


### PR DESCRIPTION
## Summary
- pre-fill shipping form fields with user address
- fix checkout timer formatting
- create express checkout session to track shipping data and 15‑minute timeout

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f1ac15d88330b4c30f4b0ecc719a