### PR TITLE
Add assistance ticket backend and UI

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -1964,10 +1964,12 @@ app.post('/cart-items', async (req, res) => {
         return res.status(401).json({ message: 'Not logged in' });
     }
 
-    const { eventCategoryId, quantity } = req.body;
+    const { eventCategoryId, quantity, isAssistanceTicket } = req.body;
     if (!eventCategoryId || quantity == null) {
         return res.status(400).json({ message: 'Missing parameters' });
     }
+
+    const assistance = Boolean(isAssistanceTicket);
 
     try {
         // 1) ensure cart exists
@@ -1978,8 +1980,9 @@ app.post('/cart-items', async (req, res) => {
             `SELECT 1
              FROM cart_items
              WHERE cart_id = $1
-               AND event_category_id = $2`,
-            [cartId, eventCategoryId]
+               AND event_category_id = $2
+               AND is_assistance_ticket = $3`,
+            [cartId, eventCategoryId, assistance]
         );
         if (dup.length) {
             return res.status(409).json({ message: 'Item already in cart' });
@@ -1999,7 +2002,11 @@ app.post('/cart-items', async (req, res) => {
         const isDisabledCat = catInfo[0].disability_support_for !== null;
 
         // 4) enforce quantity limits
-        if (isDisabledCat) {
+        if (assistance) {
+            if (quantity !== 1) {
+                return res.status(400).json({ message: 'Assistance ticket must have quantity 1' });
+            }
+        } else if (isDisabledCat) {
             // one disabled ticket per event max
             const { rows: dRows } = await client.query(
                 `SELECT COALESCE(SUM(ci.quantity),0) AS qty
@@ -2032,11 +2039,11 @@ app.post('/cart-items', async (req, res) => {
         // 5) insert the new cart_item (no price column!)
         const { rows } = await client.query(
             `INSERT INTO cart_items
-               (id, cart_id, event_id, event_category_id, quantity)
+               (id, cart_id, event_id, event_category_id, quantity, is_assistance_ticket)
              VALUES
-               ($1, $2, $3, $4, $5)
-             RETURNING id, quantity`,
-            [uuidv4(), cartId, catEventId, eventCategoryId, quantity]
+               ($1, $2, $3, $4, $5, $6)
+             RETURNING id, quantity, is_assistance_ticket`,
+            [uuidv4(), cartId, catEventId, eventCategoryId, quantity, assistance]
         );
 
         return res.status(201).json(rows[0]);
@@ -2078,7 +2085,8 @@ app.get('/cart-items', async (req, res) => {
                     t.title AS title,
                     ec.name AS category,
                     ci.quantity,
-                    ec.price AS price
+                    CASE WHEN ci.is_assistance_ticket THEN 0 ELSE ec.price END AS price,
+                    ci.is_assistance_ticket
                 FROM cart_items ci
                          JOIN events e ON e.id = ci.event_id
                          JOIN tours t ON t.id = e.tour_id
@@ -2112,7 +2120,7 @@ app.patch('/cart-items/:id', async (req, res) => {
 
         // get item details
         const { rows: itemRows } = await client.query(
-            `SELECT ci.quantity, ec.event_id, ec.disability_support_for
+            `SELECT ci.quantity, ec.event_id, ec.disability_support_for, ci.is_assistance_ticket
              FROM cart_items ci
                       JOIN event_categories ec ON ec.id = ci.event_category_id
              WHERE ci.id = $1 AND ci.cart_id = $2`,
@@ -2124,6 +2132,9 @@ app.patch('/cart-items/:id', async (req, res) => {
         const oldQty = itemRows[0].quantity;
         const eventId = itemRows[0].event_id;
         const isDisabled = itemRows[0].disability_support_for !== null;
+        if (itemRows[0].is_assistance_ticket) {
+            return res.status(400).json({ message: 'Cannot modify assistance ticket' });
+        }
 
         if (isDisabled) {
             if (quantity > 1) {
@@ -2167,7 +2178,7 @@ app.delete('/cart-items/:id', async (req, res) => {
     try {
         // 1) Fetch the cart_id for this item
         const { rows } = await client.query(
-            'SELECT cart_id FROM cart_items WHERE id = $1',
+            'SELECT cart_id, event_category_id, is_assistance_ticket FROM cart_items WHERE id = $1',
             [cartItemId]
         );
         if (rows.length === 0) {
@@ -2184,11 +2195,27 @@ app.delete('/cart-items/:id', async (req, res) => {
             return res.status(403).json({ message: 'Forbidden' });
         }
 
-        // 3) Delete it
-        await client.query(
-            'DELETE FROM cart_items WHERE id = $1',
-            [cartItemId]
+        const eventCategoryId = rows[0].event_category_id;
+        const isAssist = rows[0].is_assistance_ticket;
+
+        if (isAssist) {
+            return res.status(403).json({ message: 'Cannot delete assistance ticket directly' });
+        }
+
+        await client.query('BEGIN');
+        await client.query('DELETE FROM cart_items WHERE id = $1', [cartItemId]);
+
+        const { rows: remaining } = await client.query(
+            `SELECT 1 FROM cart_items WHERE cart_id = $1 AND event_category_id = $2 AND is_assistance_ticket = false`,
+            [cartId, eventCategoryId]
         );
+        if (remaining.length === 0) {
+            await client.query(
+                `DELETE FROM cart_items WHERE cart_id = $1 AND event_category_id = $2 AND is_assistance_ticket = true`,
+                [cartId, eventCategoryId]
+            );
+        }
+        await client.query('COMMIT');
 
         return res.status(200).json({ message: 'Deleted' });
     } catch (err) {
@@ -2234,8 +2261,9 @@ app.post('/checkout', async (req, res) => {
       SELECT
         ci.event_category_id,
         ci.quantity,
-        ec.price,
-        ec.event_id
+        CASE WHEN ci.is_assistance_ticket THEN 0 ELSE ec.price END AS price,
+        ec.event_id,
+        ci.is_assistance_ticket
       FROM cart_items ci
       JOIN carts c              ON ci.cart_id = c.id
       JOIN event_categories ec  ON ci.event_category_id = ec.id
@@ -2248,9 +2276,9 @@ app.post('/checkout', async (req, res) => {
         for (const item of cartItems) {
             await client.query(
                 `INSERT INTO checkout_items
-           (id, checkout_id, event_category_id, quantity, price, event_id)
-         VALUES ($1,$2,$3,$4,$5,$6)`,
-                [uuidv4(), checkoutId, item.event_category_id, item.quantity, item.price, item.event_id]
+           (id, checkout_id, event_category_id, quantity, price, event_id, is_assistance_ticket)
+         VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+                [uuidv4(), checkoutId, item.event_category_id, item.quantity, item.price, item.event_id, item.is_assistance_ticket]
             );
         }
 
@@ -2318,7 +2346,8 @@ app.get('/checkout-items', async (req, res) => {
                     e.start_time::time AS "eventStartTime",
                     t.tour_image   AS image,
                     ci.quantity,
-                    ci.price
+                    ci.price,
+                    ci.is_assistance_ticket
                 FROM checkout_items ci
                          JOIN event_categories ec ON ec.id        = ci.event_category_id
                          JOIN events            e  ON e.id         = ci.event_id
@@ -2377,23 +2406,43 @@ app.delete('/checkout-items/:id', async (req, res) => {
 
     const itemId = req.params.id;
     try {
-        // ensure this belongs to the user’s checkout
-        const result = await client.query(
-            `DELETE FROM checkout_items ci
-         USING checkouts co
-        WHERE ci.id = $1
-          AND ci.checkout_id = co.id
-          AND co.user_id = $2`,
+        const { rows } = await client.query(
+            `SELECT ci.checkout_id, ci.event_category_id, ci.is_assistance_ticket
+             FROM checkout_items ci
+             JOIN checkouts co ON ci.checkout_id = co.id
+             WHERE ci.id = $1 AND co.user_id = $2`,
             [itemId, userId]
         );
-
-        // rowCount===0 ⇒ not found or forbidden
-        if (result.rowCount === 0) {
+        if (!rows.length) {
             return res.status(404).json({ message: 'Item not found' });
         }
 
+        const checkoutId = rows[0].checkout_id;
+        const eventCatId = rows[0].event_category_id;
+        const isAssist = rows[0].is_assistance_ticket;
+
+        if (isAssist) {
+            return res.status(403).json({ message: 'Cannot delete assistance ticket directly' });
+        }
+
+        await client.query('BEGIN');
+        await client.query('DELETE FROM checkout_items WHERE id = $1', [itemId]);
+
+        const { rows: rest } = await client.query(
+            `SELECT 1 FROM checkout_items WHERE checkout_id = $1 AND event_category_id = $2 AND is_assistance_ticket = false`,
+            [checkoutId, eventCatId]
+        );
+        if (rest.length === 0) {
+            await client.query(
+                `DELETE FROM checkout_items WHERE checkout_id = $1 AND event_category_id = $2 AND is_assistance_ticket = true`,
+                [checkoutId, eventCatId]
+            );
+        }
+        await client.query('COMMIT');
+
         return res.json({ message: 'Item removed' });
     } catch (err) {
+        await client.query('ROLLBACK');
         console.error('Error deleting checkout item:', err);
         return res.status(500).json({ message: 'Server error' });
     }

--- a/eventim-disability-integration/src/components/nav-bar.jsx
+++ b/eventim-disability-integration/src/components/nav-bar.jsx
@@ -190,23 +190,25 @@ export default function NavBar() {
                                 ) : (
                                     <>
                                         {cartItems.map((item) => (
-                                            <div key={item.id} className="cart-row">
+                                            <div key={item.id} className={`cart-row${item.is_assistance_ticket ? ' assistance' : ''}`}>
                                                 <div className="cart-info">
                                                     <span className="cart-title">{item.title}</span>
                                                     <span className="cart-subtitle">{item.category}</span>
                                                 </div>
                                                 <div className="cart-qty">{item.quantity}</div>
-                                                <div className="cart-qty">Make the cart-items text color purple and add a small 'B' in this text box right here</div>
+                                                <div className="cart-qty assist-flag">{item.is_assistance_ticket ? 'B' : ''}</div>
                                                 <div className="cart-line-price">
                                                     {(item.quantity * parseFloat(item.price)).toFixed(2)} €
                                                 </div>
-                                                <button
-                                                    className="cart-delete-btn"
-                                                    onClick={() => deleteCartItem(item.id)}
-                                                    aria-label="Entfernen"
-                                                >
-                                                    × (make deletion button only delete non-assistance tickets, assistance tickets cannot be deleted here, but they are automatically deleted once all tickets of the same event_category were deleted)
-                                                </button>
+                                                {!item.is_assistance_ticket && (
+                                                    <button
+                                                        className="cart-delete-btn"
+                                                        onClick={() => deleteCartItem(item.id)}
+                                                        aria-label="Entfernen"
+                                                    >
+                                                        ×
+                                                    </button>
+                                                )}
                                             </div>
                                         ))}
 

--- a/eventim-disability-integration/src/hooks/useCart.js
+++ b/eventim-disability-integration/src/hooks/useCart.js
@@ -25,6 +25,7 @@ export function CartProvider({ children }) {
                 setItems(items || []);
                 const agg = {};
                 (items || []).forEach((it) => {
+                    if (it.is_assistance_ticket) return;
                     const eid = it.event_id;
                     const isDisabled = it.disability_support_for !== null && it.disability_support_for !== undefined;
                     if (!agg[eid]) agg[eid] = { regular: 0, disabled: 0 };

--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
@@ -42,6 +42,16 @@ export default function EventPage() {
         setInCartItems(map);
     }, [loggedIn, cartItems]);
 
+    const hasAssistance = (cartItems || []).some(
+        (i) => i.event_id === event && i.is_assistance_ticket
+    );
+
+    useEffect(() => {
+        if (hasAssistance) {
+            setBookingForMe(false);
+        }
+    }, [hasAssistance]);
+
 
     useEffect(() => {
         if (!artist || !tour || !event) return;
@@ -294,6 +304,7 @@ export default function EventPage() {
                                     type="checkbox"
                                     checked={bookingForMe}
                                     onChange={() => setBookingForMe(!bookingForMe)}
+                                    disabled={hasAssistance}
                                 />
                                 <span className="slider" />
                             </label>

--- a/eventim-disability-integration/src/pages/checkout/shopping-cart.jsx
+++ b/eventim-disability-integration/src/pages/checkout/shopping-cart.jsx
@@ -122,11 +122,12 @@ export default function Checkout() {
                         eventCity,
                         image,
                         quantity,
-                        price
+                        price,
+                        is_assistance_ticket
                     } = t;
 
                     return (
-                        <div key={id} className="checkoutPage__item">
+                        <div key={id} className={`checkoutPage__item${is_assistance_ticket ? ' assistance' : ''}`}>
                             <div className="checkoutPage__item-header">
                                 <img
                                     src={
@@ -139,7 +140,7 @@ export default function Checkout() {
                                     height={120}
                                 />
                                 <div className="checkoutPage__item-info">
-                                    <h2 style={{fontWeight: "bold"}}>{quantity} × <a className="venue-link" href="#" style={{color: "black"}}>{eventTitle}</a> — {category}</h2>
+                                    <h2 style={{fontWeight: "bold"}}>{quantity} × <a className="venue-link" href="#" style={{color: "black"}}>{eventTitle}</a> — {category}{is_assistance_ticket ? ' (B)' : ''}</h2>
                                     <div className="meta-item">
                                         <span className="icon-location" /> {eventCity} |{' '}
                                         <a href="#" className="venue-link" style={{color: "black"}}>{eventVenue}</a>
@@ -150,11 +151,13 @@ export default function Checkout() {
                                     </div>
                                 </div>
                             </div>
-                            <button
-                                className="checkoutPage__delete-btn"
-                                onClick={() => handleDelete(id)}
-                                aria-label="Ticket löschen"
-                            >×</button>
+                            {!is_assistance_ticket && (
+                                <button
+                                    className="checkoutPage__delete-btn"
+                                    onClick={() => handleDelete(id)}
+                                    aria-label="Ticket löschen"
+                                >×</button>
+                            )}
                         </div>
                     );
                 })}
@@ -169,8 +172,8 @@ export default function Checkout() {
                 <div className="checkoutPage__order-summary">
                     <h3>Bestellübersicht</h3>
                     {items.map(t => (
-                        <div key={t.id} className="checkoutPage__order-item">
-                            <span>{t.quantity} × {t.eventTitle}</span>
+                        <div key={t.id} className={`checkoutPage__order-item${t.is_assistance_ticket ? ' assistance' : ''}`}>
+                            <span>{t.quantity} × {t.eventTitle}{t.is_assistance_ticket ? ' (B)' : ''}</span>
                             <span>€ {(t.price * t.quantity).toFixed(2)}</span>
                         </div>
                     ))}

--- a/eventim-disability-integration/src/styles/checkout.css
+++ b/eventim-disability-integration/src/styles/checkout.css
@@ -43,6 +43,11 @@
     margin-bottom: 24px;
 }
 
+.checkoutPage__item.assistance,
+.checkoutPage__order-item.assistance {
+    color: purple;
+}
+
 .checkoutPage__item-header {
     display: flex;
     align-items: flex-start;

--- a/eventim-disability-integration/src/styles/navBar.css
+++ b/eventim-disability-integration/src/styles/navBar.css
@@ -401,6 +401,18 @@ nav-bar .dropdown-menu .dropdown-item:hover > .sub-menu {
     gap: 0.5rem;
 }
 
+.nav-bar .cart-row.assistance .cart-title,
+.nav-bar .cart-row.assistance .cart-subtitle,
+.nav-bar .cart-row.assistance .cart-qty,
+.nav-bar .cart-row.assistance .cart-line-price {
+    color: purple;
+}
+
+.nav-bar .assist-flag {
+    font-weight: bold;
+    color: purple;
+}
+
 .nav-bar .dropdown.cart .cart-delete-btn {
     margin-left: auto;
     background: transparent;


### PR DESCRIPTION
## Summary
- handle assistance tickets in cart and checkout backend
- color Begleitperson items purple and mark with `B`
- hide delete buttons for assistance tickets
- disable assistance toggle when an assistance ticket exists

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547c458668833085c45740d4dcba47