### PR TITLE
Implement assistance ticket backend and UI

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -1964,7 +1964,7 @@ app.post('/cart-items', async (req, res) => {
         return res.status(401).json({ message: 'Not logged in' });
     }
 
-    const { eventCategoryId, quantity } = req.body;
+    const { eventCategoryId, quantity, isAssistanceTicket } = req.body;
     if (!eventCategoryId || quantity == null) {
         return res.status(400).json({ message: 'Missing parameters' });
     }
@@ -1978,8 +1978,9 @@ app.post('/cart-items', async (req, res) => {
             `SELECT 1
              FROM cart_items
              WHERE cart_id = $1
-               AND event_category_id = $2`,
-            [cartId, eventCategoryId]
+               AND event_category_id = $2
+               AND is_assistance_ticket = $3`,
+            [cartId, eventCategoryId, !!isAssistanceTicket]
         );
         if (dup.length) {
             return res.status(409).json({ message: 'Item already in cart' });
@@ -1997,6 +1998,8 @@ app.post('/cart-items', async (req, res) => {
         }
         const catEventId = catInfo[0].event_id;
         const isDisabledCat = catInfo[0].disability_support_for !== null;
+
+        if (!isAssistanceTicket) {
 
         // 4) enforce quantity limits
         if (isDisabledCat) {
@@ -2028,15 +2031,16 @@ app.post('/cart-items', async (req, res) => {
                 return res.status(400).json({ message: 'Regular ticket limit exceeded' });
             }
         }
+        } // end quantity limits check
 
         // 5) insert the new cart_item (no price column!)
         const { rows } = await client.query(
             `INSERT INTO cart_items
-               (id, cart_id, event_id, event_category_id, quantity)
+               (id, cart_id, event_id, event_category_id, quantity, is_assistance_ticket)
              VALUES
-               ($1, $2, $3, $4, $5)
+               ($1, $2, $3, $4, $5, $6)
              RETURNING id, quantity`,
-            [uuidv4(), cartId, catEventId, eventCategoryId, quantity]
+            [uuidv4(), cartId, catEventId, eventCategoryId, quantity, !!isAssistanceTicket]
         );
 
         return res.status(201).json(rows[0]);
@@ -2078,7 +2082,8 @@ app.get('/cart-items', async (req, res) => {
                     t.title AS title,
                     ec.name AS category,
                     ci.quantity,
-                    ec.price AS price
+                    ci.is_assistance_ticket,
+                    CASE WHEN ci.is_assistance_ticket THEN 0 ELSE ec.price END AS price
                 FROM cart_items ci
                          JOIN events e ON e.id = ci.event_id
                          JOIN tours t ON t.id = e.tour_id
@@ -2112,7 +2117,7 @@ app.patch('/cart-items/:id', async (req, res) => {
 
         // get item details
         const { rows: itemRows } = await client.query(
-            `SELECT ci.quantity, ec.event_id, ec.disability_support_for
+            `SELECT ci.quantity, ci.is_assistance_ticket, ec.event_id, ec.disability_support_for
              FROM cart_items ci
                       JOIN event_categories ec ON ec.id = ci.event_category_id
              WHERE ci.id = $1 AND ci.cart_id = $2`,
@@ -2124,6 +2129,9 @@ app.patch('/cart-items/:id', async (req, res) => {
         const oldQty = itemRows[0].quantity;
         const eventId = itemRows[0].event_id;
         const isDisabled = itemRows[0].disability_support_for !== null;
+        if (itemRows[0].is_assistance_ticket) {
+            return res.status(400).json({ message: 'Cannot modify assistance ticket' });
+        }
 
         if (isDisabled) {
             if (quantity > 1) {
@@ -2167,7 +2175,7 @@ app.delete('/cart-items/:id', async (req, res) => {
     try {
         // 1) Fetch the cart_id for this item
         const { rows } = await client.query(
-            'SELECT cart_id FROM cart_items WHERE id = $1',
+            'SELECT cart_id, event_category_id, is_assistance_ticket FROM cart_items WHERE id = $1',
             [cartItemId]
         );
         if (rows.length === 0) {
@@ -2176,6 +2184,8 @@ app.delete('/cart-items/:id', async (req, res) => {
 
         // 2) Verify it belongs to the user
         const cartId = rows[0].cart_id;
+        const eventCategoryId = rows[0].event_category_id;
+        const isAssistance = rows[0].is_assistance_ticket;
         const { rows: ownerCheck } = await client.query(
             'SELECT 1 FROM carts WHERE id = $1 AND user_id = $2',
             [cartId, userId]
@@ -2184,11 +2194,31 @@ app.delete('/cart-items/:id', async (req, res) => {
             return res.status(403).json({ message: 'Forbidden' });
         }
 
+        if (isAssistance) {
+            return res.status(400).json({ message: 'Cannot delete assistance ticket directly' });
+        }
+
+        await client.query('BEGIN');
+
         // 3) Delete it
         await client.query(
             'DELETE FROM cart_items WHERE id = $1',
             [cartItemId]
         );
+
+        // 4) remove assistance ticket if no more regular items for category
+        const { rows: remaining } = await client.query(
+            `SELECT 1 FROM cart_items WHERE cart_id = $1 AND event_category_id = $2 AND is_assistance_ticket = false LIMIT 1`,
+            [cartId, eventCategoryId]
+        );
+        if (remaining.length === 0) {
+            await client.query(
+                'DELETE FROM cart_items WHERE cart_id = $1 AND event_category_id = $2 AND is_assistance_ticket = true',
+                [cartId, eventCategoryId]
+            );
+        }
+
+        await client.query('COMMIT');
 
         return res.status(200).json({ message: 'Deleted' });
     } catch (err) {
@@ -2234,7 +2264,8 @@ app.post('/checkout', async (req, res) => {
       SELECT
         ci.event_category_id,
         ci.quantity,
-        ec.price,
+        ci.is_assistance_ticket,
+        CASE WHEN ci.is_assistance_ticket THEN 0 ELSE ec.price END AS price,
         ec.event_id
       FROM cart_items ci
       JOIN carts c              ON ci.cart_id = c.id
@@ -2248,9 +2279,9 @@ app.post('/checkout', async (req, res) => {
         for (const item of cartItems) {
             await client.query(
                 `INSERT INTO checkout_items
-           (id, checkout_id, event_category_id, quantity, price, event_id)
-         VALUES ($1,$2,$3,$4,$5,$6)`,
-                [uuidv4(), checkoutId, item.event_category_id, item.quantity, item.price, item.event_id]
+           (id, checkout_id, event_category_id, quantity, price, event_id, is_assistance_ticket)
+         VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+                [uuidv4(), checkoutId, item.event_category_id, item.quantity, item.price, item.event_id, item.is_assistance_ticket]
             );
         }
 
@@ -2318,7 +2349,8 @@ app.get('/checkout-items', async (req, res) => {
                     e.start_time::time AS "eventStartTime",
                     t.tour_image   AS image,
                     ci.quantity,
-                    ci.price
+                    ci.price,
+                    ci.is_assistance_ticket
                 FROM checkout_items ci
                          JOIN event_categories ec ON ec.id        = ci.event_category_id
                          JOIN events            e  ON e.id         = ci.event_id

--- a/eventim-disability-integration/src/__tests__/server.test.js
+++ b/eventim-disability-integration/src/__tests__/server.test.js
@@ -6,3 +6,9 @@ test('server queries contain event_id on checkout_items', () => {
   const content = fs.readFileSync(serverPath, 'utf8');
   expect(content).toMatch(/checkout_items[^\n]*event_id/);
 });
+
+test('server handles assistance tickets', () => {
+  const serverPath = path.join(__dirname, '../../server/server.js');
+  const content = fs.readFileSync(serverPath, 'utf8');
+  expect(content).toMatch(/is_assistance_ticket/);
+});

--- a/eventim-disability-integration/src/components/nav-bar.jsx
+++ b/eventim-disability-integration/src/components/nav-bar.jsx
@@ -190,22 +190,25 @@ export default function NavBar() {
                                 ) : (
                                     <>
                                         {cartItems.map((item) => (
-                                            <div key={item.id} className="cart-row">
+                                            <div key={item.id} className={`cart-row ${item.is_assistance_ticket ? 'assistance' : ''}`}>
                                                 <div className="cart-info">
                                                     <span className="cart-title">{item.title}</span>
                                                     <span className="cart-subtitle">{item.category}</span>
                                                 </div>
                                                 <div className="cart-qty">{item.quantity}</div>
-                                                <div className="cart-qty">Make the cart-items text color purple and add a small 'B' in this text box right here</div>
+                                                <div className="cart-qty">
+                                                    {item.is_assistance_ticket && <span className="assist-flag">B</span>}
+                                                </div>
                                                 <div className="cart-line-price">
                                                     {(item.quantity * parseFloat(item.price)).toFixed(2)} €
                                                 </div>
                                                 <button
                                                     className="cart-delete-btn"
                                                     onClick={() => deleteCartItem(item.id)}
+                                                    disabled={item.is_assistance_ticket}
                                                     aria-label="Entfernen"
                                                 >
-                                                    × (make deletion button only delete non-assistance tickets, assistance tickets cannot be deleted here, but they are automatically deleted once all tickets of the same event_category were deleted)
+                                                    ×
                                                 </button>
                                             </div>
                                         ))}

--- a/eventim-disability-integration/src/hooks/useCart.js
+++ b/eventim-disability-integration/src/hooks/useCart.js
@@ -25,6 +25,7 @@ export function CartProvider({ children }) {
                 setItems(items || []);
                 const agg = {};
                 (items || []).forEach((it) => {
+                    if (it.is_assistance_ticket) return;
                     const eid = it.event_id;
                     const isDisabled = it.disability_support_for !== null && it.disability_support_for !== undefined;
                     if (!agg[eid]) agg[eid] = { regular: 0, disabled: 0 };

--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
@@ -28,6 +28,7 @@ export default function EventPage() {
     const [errorMessage, setErrorMessage] = useState('');
     const [lastClickedSection, setLastClickedSection] = useState(null);  // 'disabled' or 'regular'
     const [addDisabled, setAddDisabled] = useState(false);
+    const [assistanceInCart, setAssistanceInCart] = useState(false);
 
     // Build lookup table for items currently in cart
     useEffect(() => {
@@ -37,10 +38,21 @@ export default function EventPage() {
         }
         const map = {};
         (cartItems || []).forEach((i) => {
+            if (i.is_assistance_ticket) return;
             map[i.event_category_id] = { id: i.id, quantity: i.quantity };
         });
         setInCartItems(map);
-    }, [loggedIn, cartItems]);
+        const hasAssistance = (cartItems || []).some(
+            (i) => i.event_id === event && i.is_assistance_ticket
+        );
+        setAssistanceInCart(hasAssistance);
+    }, [loggedIn, cartItems, event]);
+
+    useEffect(() => {
+        if (assistanceInCart) {
+            setBookingForMe(false);
+        }
+    }, [assistanceInCart]);
 
 
     useEffect(() => {
@@ -199,6 +211,7 @@ export default function EventPage() {
                 ((isDisabledCatSelected ? currentCat_disabled.price : currentCat.price) || 0)
                     .toFixed(2)
             ),
+            isAssistanceTicket: false,
         };
         try {
             const res = await fetch(`${API_BASE_URL}/cart-items`, {
@@ -213,6 +226,20 @@ export default function EventPage() {
                     ...prev,
                     [selectedCat]: { id: newItem.id, quantity: newItem.quantity },
                 }));
+                if (requiresAssistance && bookingForMe) {
+                    await fetch(`${API_BASE_URL}/cart-items`, {
+                        method: 'POST',
+                        credentials: 'include',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            eventId: event,
+                            eventCategoryId: selectedCat,
+                            quantity: 1,
+                            price: 0,
+                            isAssistanceTicket: true,
+                        }),
+                    });
+                }
                 setLastClickedSection(isDisabledCatSelected ? 'disabled' : 'regular');
                 setSuccessMessage('Erfolgreich zum Warenkorb hinzugefügt!');
                 setErrorMessage('');
@@ -293,6 +320,7 @@ export default function EventPage() {
                                 <input
                                     type="checkbox"
                                     checked={bookingForMe}
+                                    disabled={assistanceInCart}
                                     onChange={() => setBookingForMe(!bookingForMe)}
                                 />
                                 <span className="slider" />

--- a/eventim-disability-integration/src/styles/navBar.css
+++ b/eventim-disability-integration/src/styles/navBar.css
@@ -416,6 +416,15 @@ nav-bar .dropdown-menu .dropdown-item:hover > .sub-menu {
     color: #b71c1c;
 }
 
+.nav-bar .cart-row.assistance {
+    color: purple;
+}
+
+.nav-bar .assist-flag {
+    color: purple;
+    font-weight: bold;
+}
+
 
 
 /* reuse .login-button.dropdown-logout for the "Weiter" button */


### PR DESCRIPTION
## Summary
- handle `is_assistance_ticket` throughout cart and checkout endpoints
- update nav bar to mark assistance tickets in purple with a `B`
- disable delete and toggle when assistance ticket exists
- automatically clean up assistance ticket on last regular deletion
- adjust hooks and event page to react to assistance items
- expand test coverage

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68547c458668833085c45740d4dcba47