### PR TITLE
Handle empty checkout and mark assistance tickets

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -2424,6 +2424,20 @@ app.delete('/checkout-items/:id', async (req, res) => {
             return res.status(404).json({ message: 'Item not found' });
         }
 
+        // check if any items remain for this user's checkout
+        const { rows: remaining } = await client.query(
+            `SELECT ci.id
+             FROM checkout_items ci
+             JOIN checkouts co ON ci.checkout_id = co.id
+             WHERE co.user_id = $1
+             LIMIT 1`,
+            [userId]
+        );
+        if (remaining.length === 0) {
+            await client.query('DELETE FROM checkouts WHERE user_id = $1', [userId]);
+            req.session.checkout = null;
+        }
+
         return res.json({ message: 'Item removed' });
     } catch (err) {
         console.error('Error deleting checkout item:', err);

--- a/eventim-disability-integration/src/pages/checkout/shopping-cart.jsx
+++ b/eventim-disability-integration/src/pages/checkout/shopping-cart.jsx
@@ -122,11 +122,12 @@ export default function Checkout() {
                         eventCity,
                         image,
                         quantity,
-                        price
+                        price,
+                        is_assistance_ticket
                     } = t;
 
                     return (
-                        <div key={id} className="checkoutPage__item">
+                        <div key={id} className={`checkoutPage__item ${is_assistance_ticket ? 'assistance' : ''}`}>
                             <div className="checkoutPage__item-header">
                                 <img
                                     src={
@@ -139,7 +140,10 @@ export default function Checkout() {
                                     height={120}
                                 />
                                 <div className="checkoutPage__item-info">
-                                    <h2 style={{fontWeight: "bold"}}>{quantity} × <a className="venue-link" href="#" style={{color: "black"}}>{eventTitle}</a> — {category}</h2>
+                                    <h2 style={{fontWeight: 'bold'}}>
+                                        {quantity} × <a className="venue-link" href="#" style={{color: 'black'}}>{eventTitle}</a> — {category}
+                                        {is_assistance_ticket && <span className="assist-flag" style={{marginLeft: '6px'}}>B</span>}
+                                    </h2>
                                     <div className="meta-item">
                                         <span className="icon-location" /> {eventCity} |{' '}
                                         <a href="#" className="venue-link" style={{color: "black"}}>{eventVenue}</a>
@@ -153,6 +157,8 @@ export default function Checkout() {
                             <button
                                 className="checkoutPage__delete-btn"
                                 onClick={() => handleDelete(id)}
+                                disabled={is_assistance_ticket}
+                                style={{color: is_assistance_ticket ? 'lightgray' : undefined}}
                                 aria-label="Ticket löschen"
                             >×</button>
                         </div>
@@ -170,7 +176,12 @@ export default function Checkout() {
                     <h3>Bestellübersicht</h3>
                     {items.map(t => (
                         <div key={t.id} className="checkoutPage__order-item">
-                            <span>{t.quantity} × {t.eventTitle}</span>
+                            <span>
+                                {t.quantity} × {t.eventTitle}
+                                {t.is_assistance_ticket && (
+                                    <span className="assist-flag" style={{marginLeft: '4px'}}>B</span>
+                                )}
+                            </span>
                             <span>€ {(t.price * t.quantity).toFixed(2)}</span>
                         </div>
                     ))}

--- a/eventim-disability-integration/src/styles/checkout.css
+++ b/eventim-disability-integration/src/styles/checkout.css
@@ -94,6 +94,20 @@
     color: #b71c1c;
 }
 
+.checkoutPage__delete-btn:disabled {
+    color: lightgray;
+    cursor: not-allowed;
+}
+
+.checkoutPage__item.assistance {
+    color: purple;
+}
+
+.assist-flag {
+    color: purple;
+    font-weight: bold;
+}
+
 .checkoutPage__sidebar {
     flex: 1 1 0;
     display: flex;


### PR DESCRIPTION
## Summary
- differentiate assistance tickets in checkout page
- disable deleting assistance tickets in checkout
- remove checkout when last item is deleted
- style assistance items

## Testing
- `npm test -- -u` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548505899c8330901f23cd3f7a7a84