### PR TITLE
Implement checkout order creation with session payment

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -390,6 +390,42 @@ app.get('/checkout-shipping', (req, res) => {
 
     return res.json({ shippingInfo: req.session.checkout.shippingInfo || null });
 });
+// Temporäres Speichern der Zahlungsart in der Session
+app.post('/checkout-payment', (req, res) => {
+    if (!req.session.userId) {
+        return res.status(401).json({ message: 'Not logged in' });
+    }
+
+    if (!req.session.checkout) {
+        return res.status(400).json({ message: 'No active checkout' });
+    }
+
+    if (Date.now() - req.session.checkout.startedAt > 15 * 60 * 1000) {
+        req.session.checkout = null;
+        return res.status(400).json({ message: 'Checkout expired' });
+    }
+
+    req.session.checkout.paymentMethod = req.body.paymentMethod || null;
+    return res.status(200).json({ message: 'OK' });
+});
+
+// Liefert die aktuell gespeicherte Zahlungsart
+app.get('/checkout-payment', (req, res) => {
+    if (!req.session.userId) {
+        return res.status(401).json({ message: 'Not logged in' });
+    }
+
+    if (!req.session.checkout) {
+        return res.status(404).json({ message: 'No active checkout' });
+    }
+
+    if (Date.now() - req.session.checkout.startedAt > 15 * 60 * 1000) {
+        req.session.checkout = null;
+        return res.status(404).json({ message: 'Checkout expired' });
+    }
+
+    return res.json({ paymentMethod: req.session.checkout.paymentMethod || null });
+});
 app.post('/create-country', async (req, res) => {
     try {
         const { name, code } = req.body;
@@ -2445,6 +2481,93 @@ app.delete('/checkout-items/:id', async (req, res) => {
     }
 });
 
+app.post('/orders', async (req, res) => {
+    const userId = req.session.userId;
+    if (!userId) return res.status(401).json({ message: 'Not logged in' });
+
+    const sessionCheckout = req.session.checkout;
+    if (!sessionCheckout || Date.now() - sessionCheckout.startedAt > 15 * 60 * 1000) {
+        req.session.checkout = null;
+        return res.status(400).json({ message: 'Checkout expired' });
+    }
+
+    if (!sessionCheckout.shippingInfo || !sessionCheckout.paymentMethod) {
+        return res.status(400).json({ message: 'Missing checkout info' });
+    }
+
+    try {
+        await client.query('BEGIN');
+
+        // find checkout record
+        const { rows: coRows } = await client.query(
+            'SELECT id FROM checkouts WHERE user_id = $1',
+            [userId]
+        );
+        if (coRows.length === 0) {
+            await client.query('ROLLBACK');
+            return res.status(400).json({ message: 'No active checkout' });
+        }
+        const checkoutId = coRows[0].id;
+
+        const info = sessionCheckout.shippingInfo.shippingInfo || {};
+        const paymentId = sessionCheckout.paymentMethod;
+
+        const payRes = await client.query('SELECT label FROM payment_options WHERE id = $1', [paymentId]);
+        const paymentLabel = payRes.rows[0] ? payRes.rows[0].label : null;
+
+        const orderId = uuidv4();
+        await client.query(
+            `INSERT INTO orders (id, user_id, created_at, street_address, postal_code, city, country, payment_method, is_paid, salutation, first_name, last_name, company, payment_option_id)
+             VALUES ($1,$2,NOW(),$3,$4,$5,$6,$7,false,$8,$9,$10,$11,$12)`,
+            [
+                orderId,
+                userId,
+                info.streetAddress || null,
+                info.postalCode || null,
+                info.city || null,
+                info.country || null,
+                paymentLabel,
+                info.salutation || null,
+                info.firstName || null,
+                info.lastName || null,
+                info.company || null,
+                paymentId,
+            ]
+        );
+
+        const { rows: items } = await client.query(
+            'SELECT id, event_category_id, quantity, price, is_assistance_ticket FROM checkout_items WHERE checkout_id = $1',
+            [checkoutId]
+        );
+
+        for (const it of items) {
+            for (let i = 0; i < it.quantity; i++) {
+                const ticketId = uuidv4();
+                await client.query(
+                    `INSERT INTO tickets (id, order_id, event_category_id, price, created_at, is_assistance_ticket)
+                     VALUES ($1,$2,$3,$4,NOW(),$5)`,
+                    [ticketId, orderId, it.event_category_id, it.price, it.is_assistance_ticket]
+                );
+                await client.query(
+                    'INSERT INTO order_tickets (id, order_id, ticket_id) VALUES ($1,$2,$3)',
+                    [uuidv4(), orderId, ticketId]
+                );
+            }
+        }
+
+        await client.query('DELETE FROM checkout_items WHERE checkout_id = $1', [checkoutId]);
+        await client.query('DELETE FROM checkouts WHERE id = $1', [checkoutId]);
+        await client.query('COMMIT');
+
+        req.session.checkout = null;
+
+        return res.status(201).json({ orderId });
+    } catch (err) {
+        await client.query('ROLLBACK');
+        console.error('Error creating order:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
 app.get('/payment-options', async (req, res) => {
     try {
         const result = await client.query(

--- a/eventim-disability-integration/src/pages/checkout/payment.jsx
+++ b/eventim-disability-integration/src/pages/checkout/payment.jsx
@@ -33,6 +33,19 @@ export default function Payment() {
             .catch((err) => console.error("Error fetching payment options:", err));
     }, []);
 
+    useEffect(() => {
+        if (!paymentOptions.length) return;
+        fetch(`${API_BASE_URL}/checkout-payment`, { credentials: "include" })
+            .then((res) => (res.ok ? res.json() : null))
+            .then((data) => {
+                if (data && data.paymentMethod) {
+                    const opt = paymentOptions.find((o) => o.id === data.paymentMethod);
+                    if (opt) setSelectedPayment(opt);
+                }
+            })
+            .catch((err) => console.error("Error fetching session payment:", err));
+    }, [paymentOptions]);
+
     // --- fetch checkout items + createdAt ---
     const fetchCheckout = async () => {
         try {
@@ -103,9 +116,22 @@ export default function Payment() {
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ paymentMethod: selectedPayment.id }),
             });
-            router.push("/checkout/review");
+
+            const res = await fetch(`${API_BASE_URL}/orders`, {
+                method: "POST",
+                credentials: "include",
+            });
+
+            if (res.ok) {
+                setTimeout(() => {
+                    router.push("/");
+                }, 3000);
+            } else {
+                const data = await res.json().catch(() => ({}));
+                alert(data.message || "Fehler bei der Bestellung");
+            }
         } catch (err) {
-            console.error("Error saving payment method:", err);
+            console.error("Error creating order:", err);
         }
     };
 


### PR DESCRIPTION
## Summary
- persist selected payment method in session
- add API to create orders from checkout items
- redirect home after payment and order creation

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554a3a54c4833087114497fdf21282