### PR TITLE
Fix checkout routing and shipping

### DIFF
--- a/eventim-disability-integration/src/components/CheckoutExpiredModal.jsx
+++ b/eventim-disability-integration/src/components/CheckoutExpiredModal.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function CheckoutExpiredModal({ onClose }) {
+    return (
+        <div className="checkout-modal-overlay">
+            <div className="checkout-modal">
+                <p>Deine Reservierungszeit ist abgelaufen.</p>
+                <div className="checkout-modal-actions">
+                    <button className="btn-end" onClick={onClose}>
+                        Zur Homepage
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/eventim-disability-integration/src/pages/checkout/payment.jsx
+++ b/eventim-disability-integration/src/pages/checkout/payment.jsx
@@ -4,6 +4,22 @@
 import React, { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/router";
 import { API_BASE_URL } from "../../config";
+import CheckoutExpiredModal from "../../components/CheckoutExpiredModal";
+
+export async function getServerSideProps({ req }) {
+    const cookie = req.headers.cookie || "";
+    try {
+        const res = await fetch(`${API_BASE_URL}/checkout-items`, {
+            headers: { cookie },
+        });
+        if (res.status !== 200) {
+            return { redirect: { destination: "/", permanent: false } };
+        }
+    } catch {
+        return { redirect: { destination: "/", permanent: false } };
+    }
+    return { props: {} };
+}
 
 export default function Payment() {
     const router = useRouter();
@@ -17,6 +33,12 @@ export default function Payment() {
     // --- load payment options from DB ---
     const [paymentOptions, setPaymentOptions] = useState([]);
     const [selectedPayment, setSelectedPayment] = useState(null);
+
+    // --- shipping options and selection ---
+    const [shippingOptions, setShippingOptions] = useState([]);
+    const [selectedShipping, setSelectedShipping] = useState(null);
+
+    const [showExpiredModal, setShowExpiredModal] = useState(false);
 
     // Fetch payment options on mount
     useEffect(() => {
@@ -32,6 +54,30 @@ export default function Payment() {
             })
             .catch((err) => console.error("Error fetching payment options:", err));
     }, []);
+
+    // Fetch shipping options on mount
+    useEffect(() => {
+        fetch(`${API_BASE_URL}/shipping-options`, { credentials: "include" })
+            .then((res) => (res.ok ? res.json() : { options: [] }))
+            .then(({ options }) => setShippingOptions(options || []))
+            .catch((err) => console.error("Error fetching shipping options:", err));
+    }, []);
+
+    // After shipping options loaded, load selection from session
+    useEffect(() => {
+        if (!shippingOptions.length) return;
+        fetch(`${API_BASE_URL}/checkout-shipping`, { credentials: "include" })
+            .then((res) => (res.ok ? res.json() : null))
+            .then((data) => {
+                if (data && data.shippingInfo && data.shippingInfo.shippingMethod) {
+                    const opt = shippingOptions.find(
+                        (o) => o.id === data.shippingInfo.shippingMethod
+                    );
+                    if (opt) setSelectedShipping(opt);
+                }
+            })
+            .catch((err) => console.error("Error fetching session shipping:", err));
+    }, [shippingOptions]);
 
     // After payment options loaded, check if session stored a method
     useEffect(() => {
@@ -65,7 +111,11 @@ export default function Payment() {
                 credentials: "include",
             });
             if (res.status === 404) {
-                window.location.href = "/";
+                if (createdAt !== null) {
+                    setShowExpiredModal(true);
+                } else {
+                    window.location.href = "/";
+                }
                 return;
             }
             const { createdAt: serverCreatedAt, items: fetchedItems } =
@@ -97,8 +147,7 @@ export default function Payment() {
                     method: "DELETE",
                     credentials: "include",
                 }).finally(() => {
-                    alert("Deine Reservierungszeit ist abgelaufen.");
-                    window.location.href = "/";
+                    setShowExpiredModal(true);
                 });
             } else {
                 setTimer(remaining);
@@ -115,7 +164,7 @@ export default function Payment() {
 
     // --- compute totals ---
     const subtotal = items.reduce((sum, t) => sum + t.price * t.quantity, 0);
-    const shippingCost = 5.9; // adjust as needed
+    const shippingCost = selectedShipping ? Number(selectedShipping.price) : 0;
     const total = subtotal + shippingCost;
 
     // --- submit selected payment ---
@@ -266,7 +315,7 @@ export default function Payment() {
                                 </div>
                             ))}
                         <div className="checkoutPage__order-item">
-                            <span>Versand (–)</span>
+                            <span>Versand ({selectedShipping ? selectedShipping.label : '–'})</span>
                             <span>€ {shippingCost.toFixed(2)}</span>
                         </div>
                         <div className="checkoutPage__order-subtotal">
@@ -284,5 +333,8 @@ export default function Payment() {
                 </div>
             </div>
         </div>
+        {showExpiredModal && (
+            <CheckoutExpiredModal onClose={() => (window.location.href = '/')} />
+        )}
     );
 }

--- a/eventim-disability-integration/src/pages/checkout/shipping-information.jsx
+++ b/eventim-disability-integration/src/pages/checkout/shipping-information.jsx
@@ -4,6 +4,20 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import { API_BASE_URL } from '../../config';
+import CheckoutExpiredModal from '../../components/CheckoutExpiredModal';
+
+export async function getServerSideProps({ req }) {
+    const cookie = req.headers.cookie || '';
+    try {
+        const res = await fetch(`${API_BASE_URL}/checkout-items`, { headers: { cookie } });
+        if (res.status !== 200) {
+            return { redirect: { destination: '/', permanent: false } };
+        }
+    } catch {
+        return { redirect: { destination: '/', permanent: false } };
+    }
+    return { props: {} };
+}
 
 export default function ShippingInformation() {
     const router = useRouter();
@@ -11,6 +25,7 @@ export default function ShippingInformation() {
     const [createdAt, setCreatedAt] = useState(null);
     const [timer, setTimer] = useState(0);
     const offsetRef = useRef(0);
+    const [showExpiredModal, setShowExpiredModal] = useState(false);
 
     const [useDifferentAddress, setUseDifferentAddress] = useState(false);
     const [shippingInfo, setShippingInfo] = useState({
@@ -93,7 +108,11 @@ export default function ShippingInformation() {
         try {
             const res = await fetch(`${API_BASE_URL}/checkout-items`, { credentials: 'include' });
             if (res.status === 404) {
-                window.location.href = '/';
+                if (createdAt !== null) {
+                    setShowExpiredModal(true);
+                } else {
+                    window.location.href = '/';
+                }
                 return;
             }
             const { createdAt: serverCreatedAt, items: fetchedItems } = await res.json();
@@ -138,8 +157,7 @@ export default function ShippingInformation() {
                     method: 'DELETE',
                     credentials: 'include'
                 }).finally(() => {
-                    alert('Deine Reservierungszeit ist abgelaufen.');
-                    window.location.href = '/';
+                    setShowExpiredModal(true);
                 });
             } else {
                 setTimer(remaining);
@@ -373,6 +391,9 @@ export default function ShippingInformation() {
                 </div>
             </div>
         </div>
+        {showExpiredModal && (
+            <CheckoutExpiredModal onClose={() => (window.location.href = '/')} />
+        )}
         </div>
     );
 }

--- a/eventim-disability-integration/src/pages/checkout/shopping-cart.jsx
+++ b/eventim-disability-integration/src/pages/checkout/shopping-cart.jsx
@@ -4,12 +4,27 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import { API_BASE_URL } from '../../config'; // adjust path if needed
+import CheckoutExpiredModal from '../../components/CheckoutExpiredModal';
+
+export async function getServerSideProps({ req }) {
+    const cookie = req.headers.cookie || '';
+    try {
+        const res = await fetch(`${API_BASE_URL}/checkout-items`, { headers: { cookie } });
+        if (res.status !== 200) {
+            return { redirect: { destination: '/', permanent: false } };
+        }
+    } catch {
+        return { redirect: { destination: '/', permanent: false } };
+    }
+    return { props: {} };
+}
 
 export default function Checkout() {
     const [items, setItems] = useState([]);
     const [createdAt, setCreatedAt] = useState(null);
     const [timer, setTimer] = useState(0);
     const offsetRef = useRef(0);   // serverTime - localTime
+    const [showExpiredModal, setShowExpiredModal] = useState(false);
 
     const router = useRouter();
 
@@ -20,8 +35,12 @@ export default function Checkout() {
                 credentials: 'include'
             });
             if (res.status === 404) {
-                // no checkout → back home
-                window.location.href = '/';
+                if (createdAt !== null) {
+                    setShowExpiredModal(true);
+                } else {
+                    // no checkout → back home
+                    window.location.href = '/';
+                }
                 return;
             }
             const { createdAt: serverCreatedAt, items: fetchedItems } = await res.json();
@@ -60,8 +79,7 @@ export default function Checkout() {
                     method: 'DELETE',
                     credentials: 'include'
                 }).finally(() => {
-                    alert('Deine Reservierungszeit ist abgelaufen.');
-                    window.location.href = '/';
+                    setShowExpiredModal(true);
                 });
             } else {
                 setTimer(remaining);
@@ -263,6 +281,9 @@ export default function Checkout() {
                 </div>
             </div>
         </div>
+        {showExpiredModal && (
+            <CheckoutExpiredModal onClose={() => (window.location.href = '/')} />
+        )}
         </div>
     );
 }

--- a/eventim-disability-integration/src/pages/profile/index.jsx
+++ b/eventim-disability-integration/src/pages/profile/index.jsx
@@ -3,6 +3,21 @@
 
 import React, { useState } from "react";
 import SquareTourCard from "../../components/squareTourCard";
+import { API_BASE_URL } from "../../config";
+
+export async function getServerSideProps({ req }) {
+    const cookie = req.headers.cookie || '';
+    try {
+        const res = await fetch(`${API_BASE_URL}/session-status`, { headers: { cookie } });
+        const data = await res.json();
+        if (!data.loggedIn) {
+            return { redirect: { destination: '/login?redirect=/profile', permanent: false } };
+        }
+    } catch {
+        return { redirect: { destination: '/login?redirect=/profile', permanent: false } };
+    }
+    return { props: {} };
+}
 
 /**
  * Beispiel‐Datensatz: 8 Einträge


### PR DESCRIPTION
## Summary
- enforce active checkout before accessing pages
- add popup when checkout session expires
- display selected shipping option on payment page
- guard profile page with login check

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68556b8b4e688330bcbe0c8445529aa5