### PR TITLE
Implement orders overview in profile page

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -2641,6 +2641,71 @@ app.get('/payment-options', async (req, res) => {
     }
 });
 
+// Liefert alle Bestellungen des eingeloggten Users
+app.get('/orders', async (req, res) => {
+    const userId = req.session.userId;
+    if (!userId) return res.status(401).json({ message: 'Not logged in' });
+
+    try {
+        const { rows } = await client.query(
+            `SELECT o.id, o.created_at, COUNT(ot.ticket_id) AS ticket_count
+               FROM orders o
+               LEFT JOIN order_tickets ot ON ot.order_id = o.id
+              WHERE o.user_id = $1
+              GROUP BY o.id
+              ORDER BY o.created_at DESC`,
+            [userId]
+        );
+        return res.json({ orders: rows });
+    } catch (err) {
+        console.error('Error fetching orders:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
+// Liefert Details zu einer bestimmten Bestellung
+app.get('/orders/:id', async (req, res) => {
+    const userId = req.session.userId;
+    if (!userId) return res.status(401).json({ message: 'Not logged in' });
+    const orderId = req.params.id;
+
+    try {
+        const { rows: orderRows } = await client.query(
+            `SELECT id, created_at, street_address, postal_code, city, country,
+                    is_paid, salutation, first_name, last_name, company,
+                    payment_option_id
+               FROM orders
+              WHERE id = $1 AND user_id = $2
+              LIMIT 1`,
+            [orderId, userId]
+        );
+        if (!orderRows.length) {
+            return res.status(404).json({ message: 'Order not found' });
+        }
+        const order = orderRows[0];
+
+        const { rows: ticketRows } = await client.query(
+            `SELECT t.id,
+                    t.seat_number,
+                    t.is_assistance_ticket,
+                    ec.name  AS event_category,
+                    tu.title AS event_title
+               FROM tickets t
+                    JOIN event_categories ec ON ec.id = t.event_category_id
+                    JOIN events e          ON e.id  = ec.event_id
+                    JOIN tours  tu         ON tu.id = e.tour_id
+              WHERE t.order_id = $1
+              ORDER BY t.created_at`,
+            [orderId]
+        );
+
+        return res.json({ order, tickets: ticketRows });
+    } catch (err) {
+        console.error('Error fetching order detail:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
 app.get(/.*/, (req, res) => {
     res.redirect(301, 'http://localhost:3000');
 });

--- a/eventim-disability-integration/src/pages/profile/index.jsx
+++ b/eventim-disability-integration/src/pages/profile/index.jsx
@@ -51,6 +51,41 @@ export default function ProfilePage() {
     const [visibleCount, setVisibleCount] = useState(1);
     const carouselRef = useRef(null);
 
+    const [orders, setOrders] = useState([]);
+    const [selectedOrder, setSelectedOrder] = useState(null);
+
+    const fetchOrders = async () => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/orders`, {
+                credentials: 'include'
+            });
+            if (res.ok) {
+                const data = await res.json();
+                setOrders(Array.isArray(data.orders) ? data.orders : []);
+            }
+        } catch (err) {
+            console.error('Error fetching orders:', err);
+        }
+    };
+
+    const fetchOrderDetail = async (id) => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/orders/${id}`, {
+                credentials: 'include'
+            });
+            if (res.ok) {
+                const data = await res.json();
+                setSelectedOrder({ id, ...data });
+            }
+        } catch (err) {
+            console.error('Error fetching order detail:', err);
+        }
+    };
+
+    useEffect(() => {
+        fetchOrders();
+    }, []);
+
     // Recalculate on mount + resize
     useEffect(() => {
         const CARD_W = 180;
@@ -196,20 +231,73 @@ export default function ProfilePage() {
                             <p className="subtitle">Alle bevorstehenden Events</p>
                         </div>
 
-                        {/* Empfehlungen */}
                         <div className="content-inner">
-                            Insert a Table here with the following columns to display one order:
-                            - Order No. -> Number should be counting up how many orders the user has in the orders table (starting counting from 1, the last order has the highest number)
-                            - How many Tickets (you can find that using the number of entries under order_tickets to this order_id)
-                            - order_status: if the order created_at date is older than 3days from now, the status is "send" in green, if its more recent its "in progress" in yellow
-
-                            It should be possible to click on each order and see an overview of all data of that order (shipping address and so on ...) as well as all tickets to that order
-                            a ticket should be displayed with the following columns:
-                            - event_title: the title of the event
-                            - event_category: the category of the event
-                            - seat number: the seat number of the ticket
-                            - is_assistance_ticket: if the ticket is an assistance ticket, it should be displayed with a purple 'B' sign in a sepaarte column
+                            <table className="orders-table">
+                                <thead>
+                                    <tr>
+                                        <th>Order&nbsp;No.</th>
+                                        <th>Tickets</th>
+                                        <th>Status</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {orders.map((o, idx) => {
+                                        const orderNo = orders.length - idx;
+                                        const isSent = new Date(o.created_at).getTime() < Date.now() - 3 * 24 * 60 * 60 * 1000;
+                                        return (
+                                            <tr
+                                                key={o.id}
+                                                className="order-row"
+                                                onClick={() => fetchOrderDetail(o.id)}
+                                            >
+                                                <td>#{orderNo}</td>
+                                                <td>{o.ticket_count}</td>
+                                                <td>
+                                                    <span className={`order-status ${isSent ? 'send' : 'progress'}`}>{isSent ? 'send' : 'in progress'}</span>
+                                                </td>
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </table>
                         </div>
+
+                        {selectedOrder && (
+                            <div className="modal-overlay" onClick={() => setSelectedOrder(null)}>
+                                <div className="modal-box" onClick={e => e.stopPropagation()}>
+                                    <h3>Bestellung #{orders.findIndex(o => o.id === selectedOrder.id) >= 0 ? orders.length - orders.findIndex(o => o.id === selectedOrder.id) : ''}</h3>
+                                    <div className="order-detail-shipping">
+                                        <p>{selectedOrder.order.salutation} {selectedOrder.order.first_name} {selectedOrder.order.last_name}</p>
+                                        <p>{selectedOrder.order.street_address}</p>
+                                        <p>{selectedOrder.order.postal_code} {selectedOrder.order.city}</p>
+                                        <p>{selectedOrder.order.country}</p>
+                                    </div>
+                                    <table className="tickets-table">
+                                        <thead>
+                                            <tr>
+                                                <th>Event</th>
+                                                <th>Kategorie</th>
+                                                <th>Sitz</th>
+                                                <th>B</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            {selectedOrder.tickets.map(t => (
+                                                <tr key={t.id}>
+                                                    <td>{t.event_title}</td>
+                                                    <td>{t.event_category}</td>
+                                                    <td>{t.seat_number}</td>
+                                                    <td>{t.is_assistance_ticket ? <span className="assist-flag">B</span> : ''}</td>
+                                                </tr>
+                                            ))}
+                                        </tbody>
+                                    </table>
+                                    <div className="modal-actions">
+                                        <button className="btn btn-cancel" onClick={() => setSelectedOrder(null)}>Schließen</button>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
                     </div>
 
                     {/* Help Center / FAQ */}

--- a/eventim-disability-integration/src/styles/profile.css
+++ b/eventim-disability-integration/src/styles/profile.css
@@ -302,7 +302,56 @@
 }
 
 /* -----------------------------------
-   10) Help Center / FAQ
+   10) Orders Table
+   ----------------------------------- */
+.orders-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+}
+.orders-table th,
+.orders-table td {
+    padding: 0.5rem;
+    border-bottom: 1px solid #e0e0e0;
+    text-align: left;
+}
+.orders-table th {
+    background-color: #f0f0f0;
+    color: #002b55;
+    font-weight: 600;
+}
+.order-row:hover {
+    background-color: #f9f9f9;
+    cursor: pointer;
+}
+.order-status.send {
+    color: green;
+}
+.order-status.progress {
+    color: #ffc700;
+}
+.order-detail-shipping p {
+    margin: 0;
+}
+.tickets-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+.tickets-table th,
+.tickets-table td {
+    padding: 0.4rem;
+    border-bottom: 1px solid #ddd;
+    text-align: left;
+}
+.tickets-table th {
+    background-color: #fafafa;
+    color: #002b55;
+    font-weight: 600;
+}
+
+/* -----------------------------------
+   11) Help Center / FAQ
    ----------------------------------- */
 .help-section {
     padding: 0;


### PR DESCRIPTION
## Summary
- enable fetching user orders via backend endpoints
- display orders list in profile page
- show modal with order details and tickets
- style orders table in profile section

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6858172d6c888330ae464bbe10c672ed