### PR TITLE
Profile uses DB data

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -2670,6 +2670,41 @@ app.get('/orders', async (req, res) => {
     }
 });
 
+// Liefert alle Events, für die der eingeloggte Nutzer Tickets besitzt
+app.get('/my-events', async (req, res) => {
+    const userId = req.session.userId;
+    if (!userId) return res.status(401).json({ message: 'Not logged in' });
+
+    try {
+        const { rows } = await client.query(
+            `SELECT
+                e.id         AS event_id,
+                e.start_time,
+                v.name       AS venue_name,
+                c.name       AS city_name,
+                t.id         AS tour_id,
+                t.title      AS tour_title,
+                t.tour_image,
+                (SELECT artist_id FROM tour_artists WHERE tour_id = t.id LIMIT 1) AS artist_id
+             FROM tickets tk
+                  JOIN orders o           ON o.id  = tk.order_id
+                  JOIN event_categories ec ON ec.id = tk.event_category_id
+                  JOIN events e           ON e.id  = ec.event_id
+                  JOIN tours t            ON t.id  = e.tour_id
+                  JOIN venues v           ON v.id  = e.venue_id
+                  JOIN cities c           ON c.id  = v.city_id
+             WHERE o.user_id = $1
+             GROUP BY e.id, e.start_time, v.name, c.name, t.id, t.title, t.tour_image
+             ORDER BY e.start_time`,
+            [userId]
+        );
+        return res.json({ events: rows });
+    } catch (err) {
+        console.error('Error fetching my events:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
 // Liefert Details zu einer bestimmten Bestellung
 app.get('/orders/:id', async (req, res) => {
     const userId = req.session.userId;

--- a/eventim-disability-integration/src/components/squareTourCard.jsx
+++ b/eventim-disability-integration/src/components/squareTourCard.jsx
@@ -7,10 +7,10 @@ import React, { useState, useEffect } from "react";
  * Props:
  * - imageId:    UUID der Tour-Bilddatei in der Datenbank
  * - title:      String, z.B. "Rod Stewart"
- * - priceText:  String, z.B. "Tickets ab € 68,00"
- * - link:       URL, auf die beim Klick auf Titel/Preis navigiert wird
+ * - bottomText: String unter dem Titel (Datum/Venue)
+ * - link:       URL, auf die beim Klick auf den Text navigiert wird
  */
-const SquareTourCard = ({ imageId, title, priceText, link }) => {
+const SquareTourCard = ({ imageId, title, bottomText, link }) => {
     const [imageUrl, setImageUrl] = useState(null);
 
     useEffect(() => {
@@ -60,7 +60,7 @@ const SquareTourCard = ({ imageId, title, priceText, link }) => {
                 <h2 className="square-tourCard-title">{title}</h2>
                 <p className="square-tourCard-price">
                     <a href={link} className="square-tourCard-link">
-                        {priceText}
+                        {bottomText}
                     </a>
                 </p>
             </div>

--- a/eventim-disability-integration/src/pages/profile/index.jsx
+++ b/eventim-disability-integration/src/pages/profile/index.jsx
@@ -31,17 +31,6 @@ export async function getServerSideProps({ req }) {
     return { props: {} };
 }
 
-const sampleTourData = [
-    { imageId: "90bbc401-2984-494b-a34c-59831427a0b3", title: "Rod Stewart",         priceText: "Tickets ab € 68,00", link: "#" },
-    { imageId: "f1d49502-0d05-4ea8-b347-2b22cac9ea65", title: "Tom Odell",           priceText: "Tickets ab € 60,40", link: "#" },
-    { imageId: "d3b82c8c-4c08-4859-88a2-ca4cfebc08df", title: "Disney In Concert",   priceText: "Tickets ab € 59,90", link: "#" },
-    { imageId: "82a3438f-83a4-475a-90a3-fc9fe951faac", title: "Schwanensee – Ballett", priceText: "Tickets ab € 42,00", link: "#" },
-    { imageId: "5da11a45-7366-42dc-8604-e81851271b25", title: "Ehrlich Brothers",    priceText: "Tickets ab € 52,00", link: "#" },
-    { imageId: "1dd71154-1920-4c77-99f1-94e08572eb78", title: "Tom Gaebel",          priceText: "Tickets ab € 39,90", link: "#" },
-    { imageId: "68368c8c-2094-463a-8698-adea0440b44c", title: "Teddy Teclebrhan",    priceText: "Tickets ab € 42,25", link: "#" },
-    { imageId: "9fde1a84-3a64-4a0a-9210-7c9bb3dcb7e5", title: "Lars Eidinger",       priceText: "Tickets ab € 35,00", link: "#" },
-];
-
 export default function ProfilePage() {
     // Carousel indices
     const [carouselIndex, setCarouselIndex] = useState(0);
@@ -53,6 +42,9 @@ export default function ProfilePage() {
     const [selectedOrder, setSelectedOrder] = useState(null);
 
     const [qrTicketId, setQrTicketId] = useState(null);
+
+    const [myEvents, setMyEvents] = useState([]);
+    const [tours, setTours] = useState([]);
 
     const [activeSidebarItem, setActiveSidebarItem] = useState("Meine Events");
     // refs for each section
@@ -95,6 +87,30 @@ export default function ProfilePage() {
         }
     };
 
+    const fetchMyEvents = async () => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/my-events`, { credentials: 'include' });
+            if (res.ok) {
+                const data = await res.json();
+                setMyEvents(Array.isArray(data.events) ? data.events : []);
+            }
+        } catch (err) {
+            console.error('Error fetching events:', err);
+        }
+    };
+
+    const fetchTours = async () => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/tours-detailed`);
+            if (res.ok) {
+                const data = await res.json();
+                setTours(Array.isArray(data.tours) ? data.tours : []);
+            }
+        } catch (err) {
+            console.error('Error fetching tours:', err);
+        }
+    };
+
     const fetchOrderDetail = async (id) => {
         try {
             const res = await fetch(`${API_BASE_URL}/orders/${id}`, {
@@ -111,6 +127,8 @@ export default function ProfilePage() {
 
     useEffect(() => {
         fetchOrders();
+        fetchMyEvents();
+        fetchTours();
     }, []);
 
     // Recalculate on mount + resize
@@ -122,7 +140,7 @@ export default function ProfilePage() {
             const count = Math.floor((w + GAP) / (CARD_W + GAP));
             const clamp = Math.min(8, Math.max(1, count));
             setVisibleCount(clamp);
-            setCarouselIndex(ci => Math.min(ci, sampleTourData.length - clamp));
+            setCarouselIndex(ci => Math.min(ci, tours.length - clamp));
         }
         updateCount();
         window.addEventListener("resize", updateCount);
@@ -133,16 +151,9 @@ export default function ProfilePage() {
         if (carouselIndex > 0) setCarouselIndex(i => i - 1);
     };
     const handleNext = () => {
-        if (carouselIndex < sampleTourData.length - visibleCount)
+        if (carouselIndex < tours.length - visibleCount)
             setCarouselIndex(i => i + 1);
     };
-
-    // Slices for blue cards (Meine Events) and recommendations
-    const blueCards = sampleTourData.slice(0, visibleCount);
-    const recommendCards = sampleTourData.slice(
-        carouselIndex,
-        carouselIndex + visibleCount
-    );
 
     const formatDate = (d) =>
         new Date(d).toLocaleDateString('de-DE', {
@@ -153,6 +164,13 @@ export default function ProfilePage() {
         });
     const formatTime = (d) =>
         new Date(d).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+
+    // Slices for blue cards (Meine Events) and recommendations
+    const blueCards = myEvents.slice(0, visibleCount);
+    const recommendCards = tours.slice(
+        carouselIndex,
+        carouselIndex + visibleCount
+    );
 
     const closeModal = () => {
         setQrTicketId(null);
@@ -218,8 +236,14 @@ export default function ProfilePage() {
                             <div className="content-inner">
                                 <div className="cards-container">
                                     <div className="blue-cards">
-                                        {blueCards.map(t => (
-                                            <SquareTourCard key={t.imageId} {...t} />
+                                        {blueCards.map(ev => (
+                                            <SquareTourCard
+                                                key={ev.event_id}
+                                                imageId={ev.tour_image}
+                                                title={ev.tour_title}
+                                                bottomText={`${formatDate(ev.start_time)} | ${ev.venue_name}`}
+                                                link={`/artists/${ev.artist_id}/${ev.tour_id}/${ev.event_id}`}
+                                            />
                                         ))}
                                     </div>
                                 </div>
@@ -243,18 +267,25 @@ export default function ProfilePage() {
                                         ‹
                                     </button>
                                     <div className="carousel-track">
-                                        {recommendCards.map((t, i) => (
-                                            <SquareTourCard
-                                                key={carouselIndex + i}
-                                                {...t}
-                                            />
-                                        ))}
+                                        {recommendCards.map((t, i) => {
+                                            const ev = t.events && t.events[0];
+                                            if (!ev) return null;
+                                            return (
+                                                <SquareTourCard
+                                                    key={carouselIndex + i}
+                                                    imageId={t.tour_image}
+                                                    title={t.title}
+                                                    bottomText={`${formatDate(ev.start_time)} | ${ev.venueName}`}
+                                                    link={`/artists/${t.artistIds && t.artistIds[0]}/${t.id}/${ev.id}`}
+                                                />
+                                            );
+                                        })}
                                     </div>
                                     <button
                                         className="carousel-button right"
                                         onClick={handleNext}
                                         disabled={
-                                            carouselIndex >= sampleTourData.length - visibleCount
+                                            carouselIndex >= tours.length - visibleCount
                                         }
                                     >
                                         ›


### PR DESCRIPTION
## Summary
- add `/my-events` endpoint to fetch upcoming events for the logged-in user
- show event date & venue in `SquareTourCard`
- connect profile page to database for events and tour highlights

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858faffbe708330b8bb5a30d514b936