### PR TITLE
Hook profile page up to database

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -2713,6 +2713,42 @@ app.get('/orders/:id', async (req, res) => {
     }
 });
 
+// Liefert alle Events, für die der eingeloggte User Tickets besitzt
+app.get('/my-events', async (req, res) => {
+    const userId = req.session.userId;
+    if (!userId) return res.status(401).json({ message: 'Not logged in' });
+
+    try {
+        const { rows } = await client.query(
+            `SELECT
+                e.id           AS event_id,
+                e.tour_id,
+                t.title        AS tour_title,
+                t.tour_image,
+                v.name         AS venue_name,
+                e.start_time,
+                (SELECT ta.artist_id FROM tour_artists ta
+                    WHERE ta.tour_id = t.id LIMIT 1) AS artist_id
+             FROM orders o
+                  JOIN order_tickets ot ON ot.order_id = o.id
+                  JOIN tickets ti       ON ti.id = ot.ticket_id
+                  JOIN event_categories ec ON ec.id = ti.event_category_id
+                  JOIN events e         ON e.id = ec.event_id
+                  JOIN tours t          ON t.id = e.tour_id
+                  JOIN venues v         ON v.id = e.venue_id
+             WHERE o.user_id = $1
+             GROUP BY e.id, e.tour_id, t.title, t.tour_image,
+                      v.name, e.start_time, t.id
+             ORDER BY e.start_time`,
+            [userId]
+        );
+        return res.json({ events: rows });
+    } catch (err) {
+        console.error('Error fetching my events:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
 app.get(/.*/, (req, res) => {
     res.redirect(301, 'http://localhost:3000');
 });

--- a/eventim-disability-integration/src/components/squareTourCard.jsx
+++ b/eventim-disability-integration/src/components/squareTourCard.jsx
@@ -7,10 +7,10 @@ import React, { useState, useEffect } from "react";
  * Props:
  * - imageId:    UUID der Tour-Bilddatei in der Datenbank
  * - title:      String, z.B. "Rod Stewart"
- * - priceText:  String, z.B. "Tickets ab € 68,00"
- * - link:       URL, auf die beim Klick auf Titel/Preis navigiert wird
+ * - infoText:   Zusatzinfo, z.B. Datum und Venue
+ * - link:       URL, auf die beim Klick auf Titel/Info navigiert wird
  */
-const SquareTourCard = ({ imageId, title, priceText, link }) => {
+const SquareTourCard = ({ imageId, title, infoText, link }) => {
     const [imageUrl, setImageUrl] = useState(null);
 
     useEffect(() => {
@@ -60,7 +60,7 @@ const SquareTourCard = ({ imageId, title, priceText, link }) => {
                 <h2 className="square-tourCard-title">{title}</h2>
                 <p className="square-tourCard-price">
                     <a href={link} className="square-tourCard-link">
-                        {priceText}
+                        {infoText}
                     </a>
                 </p>
             </div>

--- a/eventim-disability-integration/src/pages/profile/index.jsx
+++ b/eventim-disability-integration/src/pages/profile/index.jsx
@@ -31,16 +31,6 @@ export async function getServerSideProps({ req }) {
     return { props: {} };
 }
 
-const sampleTourData = [
-    { imageId: "90bbc401-2984-494b-a34c-59831427a0b3", title: "Rod Stewart",         priceText: "Tickets ab € 68,00", link: "#" },
-    { imageId: "f1d49502-0d05-4ea8-b347-2b22cac9ea65", title: "Tom Odell",           priceText: "Tickets ab € 60,40", link: "#" },
-    { imageId: "d3b82c8c-4c08-4859-88a2-ca4cfebc08df", title: "Disney In Concert",   priceText: "Tickets ab € 59,90", link: "#" },
-    { imageId: "82a3438f-83a4-475a-90a3-fc9fe951faac", title: "Schwanensee – Ballett", priceText: "Tickets ab € 42,00", link: "#" },
-    { imageId: "5da11a45-7366-42dc-8604-e81851271b25", title: "Ehrlich Brothers",    priceText: "Tickets ab € 52,00", link: "#" },
-    { imageId: "1dd71154-1920-4c77-99f1-94e08572eb78", title: "Tom Gaebel",          priceText: "Tickets ab € 39,90", link: "#" },
-    { imageId: "68368c8c-2094-463a-8698-adea0440b44c", title: "Teddy Teclebrhan",    priceText: "Tickets ab € 42,25", link: "#" },
-    { imageId: "9fde1a84-3a64-4a0a-9210-7c9bb3dcb7e5", title: "Lars Eidinger",       priceText: "Tickets ab € 35,00", link: "#" },
-];
 
 export default function ProfilePage() {
     // Carousel indices
@@ -53,6 +43,9 @@ export default function ProfilePage() {
     const [selectedOrder, setSelectedOrder] = useState(null);
 
     const [qrTicketId, setQrTicketId] = useState(null);
+
+    const [myEvents, setMyEvents] = useState([]);
+    const [tours, setTours] = useState([]);
 
     const [activeSidebarItem, setActiveSidebarItem] = useState("Meine Events");
     // refs for each section
@@ -109,8 +102,61 @@ export default function ProfilePage() {
         }
     };
 
+    const formatDate = (d) =>
+        new Date(d).toLocaleDateString('de-DE', {
+            weekday: 'long',
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+        });
+    const formatTime = (d) =>
+        new Date(d).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+    const fetchMyEvents = async () => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/my-events`, { credentials: 'include' });
+            if (res.ok) {
+                const data = await res.json();
+                const arr = Array.isArray(data.events) ? data.events : [];
+                const mapped = arr.map(ev => ({
+                    imageId: ev.tour_image,
+                    title: ev.tour_title,
+                    infoText: `${formatDate(ev.start_time)} | ${ev.venue_name}`,
+                    link: `/artists/${ev.artist_id}/${ev.tour_id}/${ev.event_id}`
+                }));
+                setMyEvents(mapped);
+            }
+        } catch (err) {
+            console.error('Error fetching my events:', err);
+        }
+    };
+
+    const fetchTours = async () => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/tours-detailed`);
+            if (res.ok) {
+                const data = await res.json();
+                const arr = Array.isArray(data.tours) ? data.tours : [];
+                const mapped = arr.map(t => {
+                    const ev = t.events && t.events[0];
+                    const artistId = (t.artistIds || [])[0];
+                    return {
+                        imageId: t.tour_image,
+                        title: t.title,
+                        infoText: ev ? `${formatDate(ev.start_time)} | ${ev.venueName}` : '',
+                        link: ev && artistId ? `/artists/${artistId}/${t.id}/${ev.id}` : '#'
+                    };
+                });
+                setTours(mapped);
+            }
+        } catch (err) {
+            console.error('Error fetching tours:', err);
+        }
+    };
+
     useEffect(() => {
         fetchOrders();
+        fetchMyEvents();
+        fetchTours();
     }, []);
 
     // Recalculate on mount + resize
@@ -122,7 +168,7 @@ export default function ProfilePage() {
             const count = Math.floor((w + GAP) / (CARD_W + GAP));
             const clamp = Math.min(8, Math.max(1, count));
             setVisibleCount(clamp);
-            setCarouselIndex(ci => Math.min(ci, sampleTourData.length - clamp));
+            setCarouselIndex(ci => Math.min(ci, tours.length - clamp));
         }
         updateCount();
         window.addEventListener("resize", updateCount);
@@ -133,26 +179,16 @@ export default function ProfilePage() {
         if (carouselIndex > 0) setCarouselIndex(i => i - 1);
     };
     const handleNext = () => {
-        if (carouselIndex < sampleTourData.length - visibleCount)
+        if (carouselIndex < tours.length - visibleCount)
             setCarouselIndex(i => i + 1);
     };
 
     // Slices for blue cards (Meine Events) and recommendations
-    const blueCards = sampleTourData.slice(0, visibleCount);
-    const recommendCards = sampleTourData.slice(
+    const blueCards = myEvents.slice(0, visibleCount);
+    const recommendCards = tours.slice(
         carouselIndex,
         carouselIndex + visibleCount
     );
-
-    const formatDate = (d) =>
-        new Date(d).toLocaleDateString('de-DE', {
-            weekday: 'long',
-            day: '2-digit',
-            month: '2-digit',
-            year: 'numeric',
-        });
-    const formatTime = (d) =>
-        new Date(d).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
 
     const closeModal = () => {
         setQrTicketId(null);
@@ -254,7 +290,7 @@ export default function ProfilePage() {
                                         className="carousel-button right"
                                         onClick={handleNext}
                                         disabled={
-                                            carouselIndex >= sampleTourData.length - visibleCount
+                                            carouselIndex >= tours.length - visibleCount
                                         }
                                     >
                                         ›


### PR DESCRIPTION
## Summary
- connect profile page to the backend
- show events bought by the user and all available tours
- display event date and venue on SquareTourCard
- add `/my-events` endpoint on the server

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858faffbe708330b8bb5a30d514b936