### PR TITLE
Add tour events page

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -1942,6 +1942,166 @@ app.get('/event-accessibility', async (req, res) => {
     }
 });
 
+// Liefert Detailinformationen zu einer Tour inklusive aller Events
+app.get('/tour-details/:id', async (req, res) => {
+    const tourId = req.params.id;
+    try {
+        const { rows: tourRows } = await client.query(
+            `SELECT id, title, subtitle, start_date, end_date, tour_image
+             FROM tours WHERE id = $1`,
+            [tourId]
+        );
+        if (tourRows.length === 0) {
+            return res.status(404).json({ message: 'Tour nicht gefunden' });
+        }
+
+        const tour = tourRows[0];
+
+        const { rows: countRows } = await client.query(
+            `SELECT COUNT(*) AS "eventCount" FROM events WHERE tour_id = $1`,
+            [tourId]
+        );
+        const eventCount = parseInt(countRows[0].eventCount, 10);
+
+        const { rows: cheapestRows } = await client.query(
+            `SELECT MIN(ec.price)::numeric(10,2) AS "cheapestPrice"
+               FROM event_categories ec
+                    JOIN events e ON e.id = ec.event_id
+              WHERE e.tour_id = $1
+                AND ec.disability_support_for IS NULL`,
+            [tourId]
+        );
+        const cheapestPrice = cheapestRows[0].cheapestPrice !== null
+            ? parseFloat(cheapestRows[0].cheapestPrice)
+            : null;
+
+        const { rows: allMarks } = await client.query(
+            `SELECT area_id, mark_code FROM disability_marks WHERE area_id IS NOT NULL`
+        );
+        const marksMap = {};
+        allMarks.forEach((row) => {
+            const aid = row.area_id;
+            const code = row.mark_code.trim();
+            if (!marksMap[aid]) marksMap[aid] = [];
+            if (!marksMap[aid].includes(code)) marksMap[aid].push(code);
+        });
+
+        const { rows: baseEvents } = await client.query(
+            `SELECT e.id,
+                    e.description,
+                    e.start_time,
+                    e.end_time,
+                    e.door_time,
+                    v.name AS "venueName",
+                    c.name AS "cityName"
+               FROM events e
+                    JOIN venues v ON v.id = e.venue_id
+                    JOIN cities c ON c.id = v.city_id
+              WHERE e.tour_id = $1
+              ORDER BY e.start_time`,
+            [tourId]
+        );
+
+        const events = await Promise.all(
+            baseEvents.map(async (ev) => {
+                const { rows: evaRows } = await client.query(
+                    `SELECT venue_area_id FROM event_venue_areas WHERE event_id = $1`,
+                    [ev.id]
+                );
+                const areaIds = [];
+                for (const eva of evaRows) {
+                    const { rows: vaRows } = await client.query(
+                        `SELECT area_id FROM venue_areas WHERE id = $1`,
+                        [eva.venue_area_id]
+                    );
+                    if (vaRows[0] && vaRows[0].area_id) areaIds.push(vaRows[0].area_id);
+                }
+                const collectedCodes = new Set();
+                areaIds.forEach((aid) => {
+                    if (marksMap[aid]) {
+                        marksMap[aid].forEach((c) => collectedCodes.add(c));
+                    }
+                });
+                const labels = Array.from(collectedCodes)
+                    .map((code) => {
+                        switch (code) {
+                            case 'G':
+                            case 'aG':
+                                return 'Rollstuhlplätze verfügbar';
+                            case 'Gl':
+                                return 'Gehörlosenplätze verfügbar';
+                            case 'Bl':
+                                return 'Blindenplätze verfügbar';
+                            default:
+                                return null;
+                        }
+                    })
+                    .filter((l) => l !== null);
+                return {
+                    id: ev.id,
+                    description: ev.description,
+                    cityName: ev.cityName,
+                    venueName: ev.venueName,
+                    start_time: ev.start_time,
+                    end_time: ev.end_time,
+                    door_time: ev.door_time,
+                    accessibility: Array.from(new Set(labels)),
+                };
+            })
+        );
+
+        const { rows: artistRows } = await client.query(
+            `SELECT a.id, a.name
+               FROM tour_artists ta
+                    JOIN artists a ON a.id = ta.artist_id
+              WHERE ta.tour_id = $1
+              ORDER BY a.name`,
+            [tourId]
+        );
+        const artistsList = artistRows.map((r) => r.name);
+        const artistIds = artistRows.map((r) => r.id);
+
+        const { rows: genreRows } = await client.query(
+            `SELECT g.id AS "genreId",
+                    g.name AS "genreName",
+                    COALESCE(json_agg(s.name) FILTER (WHERE s.id IS NOT NULL), '[]') AS "subgenreNames"
+               FROM tour_genres tg
+                    JOIN genres g ON g.id = tg.genre_id
+                    LEFT JOIN tour_subgenres ts ON ts.tour_id = tg.tour_id
+                    LEFT JOIN subgenres s ON s.id = ts.subgenre_id AND s.genre_id = tg.genre_id
+              WHERE tg.tour_id = $1
+              GROUP BY g.id, g.name
+              ORDER BY g.name`,
+            [tourId]
+        );
+        const genresWithSubs = genreRows.map((r) => ({
+            genreId: r.genreid,
+            genreName: r.genrename,
+            subgenreNames: r.subgenrenames || [],
+        }));
+
+        return res.status(200).json({
+            tour: {
+                id: tour.id,
+                title: tour.title,
+                subtitle: tour.subtitle,
+                start_date: tour.start_date,
+                end_date: tour.end_date,
+                tour_image: tour.tour_image,
+                eventCount,
+                cheapestPrice,
+                artistsList,
+                artistIds,
+                genresWithSubs,
+                events,
+            },
+        });
+    } catch (err) {
+        console.error('Error in /tour-details:', err);
+        return res.status(500).json({ message: 'Fehler beim Laden der Tour' });
+    }
+});
+
 // Liefert Detailinformationen zu einem Event inklusive Kategorien und zugehörigen Künstler-IDs
 app.get('/event-details/:id', async (req, res) => {
     const eventId = req.params.id;

--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/index.jsx
@@ -1,0 +1,134 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { API_BASE_URL } from '../../../../config';
+
+export default function TourEventsPage() {
+    const router = useRouter();
+    const { artist, tour } = router.query;
+
+    const [tourData, setTourData] = useState(null);
+    const [events, setEvents] = useState([]);
+
+    useEffect(() => {
+        if (!tour) return;
+        const load = async () => {
+            try {
+                const res = await fetch(`${API_BASE_URL}/tour-details/${tour}`);
+                if (!res.ok) throw new Error();
+                const data = await res.json();
+                setTourData(data.tour);
+                const evs = Array.isArray(data.tour.events) ? data.tour.events : [];
+                evs.sort((a, b) => new Date(a.start_time) - new Date(b.start_time));
+                setEvents(evs);
+            } catch (err) {
+                console.error(err);
+                setTourData(null);
+            }
+        };
+        load();
+    }, [tour]);
+
+    if (!tourData) return <div>Loading …</div>;
+
+    const formatDate = (d) =>
+        new Date(d).toLocaleDateString('de-DE', {
+            weekday: 'short',
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+        });
+    const formatTime = (d) =>
+        new Date(d).toLocaleTimeString('de-DE', {
+            hour: '2-digit',
+            minute: '2-digit',
+        });
+
+    return (
+        <div className="event-container">
+            <header className="event-header">
+                <div className="header-info">
+                    <h1 className="event-title">{tourData.title}</h1>
+                    {tourData.subtitle && <p>{tourData.subtitle}</p>}
+                    <div className="event-meta">
+                        <div className="meta-item">
+                            {new Date(tourData.start_date).toLocaleDateString('de-DE')} –{' '}
+                            {new Date(tourData.end_date).toLocaleDateString('de-DE')}
+                        </div>
+                        <div className="meta-item">{tourData.eventCount} Events</div>
+                    </div>
+                </div>
+                <div className="event-hero">
+                    <img
+                        src={
+                            tourData.tour_image
+                                ? `${API_BASE_URL}/image/${tourData.tour_image}`
+                                : '/placeholder-tour.png'
+                        }
+                        alt={tourData.title || 'Tour'}
+                    />
+                </div>
+            </header>
+
+            <div className="artists-wrapper">
+                <div className="tours-grid">
+                    {events.length === 0 && (
+                        <div className="no-artists">Keine Events vorhanden.</div>
+                    )}
+                    {events.map((ev) => {
+                        const evUrl = `/artists/${artist}/${tour}/${ev.id}`;
+                        const evAcc = Array.from(new Set(ev.accessibility || []));
+                        return (
+                            <div className="artist-card" key={ev.id}>
+                                <div className="card-body">
+                                    <div className="details-wrapper">
+                                        <div
+                                            className="tour-header hoverable"
+                                            onClick={() => router.push(evUrl)}
+                                        >
+                                            <div>
+                                                <h3 className="tour-title">
+                                                    {formatDate(ev.start_time)} | {ev.cityName}
+                                                </h3>
+                                                <div className="tour-meta">
+                                                    <span>{formatTime(ev.start_time)}</span>
+                                                    <span>• {ev.venueName}</span>
+                                                </div>
+                                                {evAcc.length > 0 && (
+                                                    <div className="tour-accessibility">
+                                                        {evAcc.map((lbl) => (
+                                                            <span
+                                                                key={lbl}
+                                                                className="access-label-small"
+                                                            >
+                                                                {lbl}
+                                                            </span>
+                                                        ))}
+                                                    </div>
+                                                )}
+                                            </div>
+                                            <div className="header-right">
+                                                <button
+                                                    className="btn-view-events"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        router.push(evUrl);
+                                                    }}
+                                                >
+                                                    Tickets
+                                                </button>
+                                            </div>
+                                        </div>
+                                        {ev.description && (
+                                            <div className="sub-event-details">{ev.description}</div>
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            </div>
+        </div>
+    );
+}
+


### PR DESCRIPTION
## Summary
- implement `/tour-details/:id` endpoint for tour info with events
- create frontend page at `/artists/[artist]/[tour]` to display a tour's events

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593ccd798c8330a842dae3a0ad9e0f