### PR TITLE
Add searchable tours in navbar

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -1253,6 +1253,77 @@ app.get("/artists-with-images", async (req, res) => {
     }
 });
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Suche nach Touren (inkl. 2 nächster Events) mit einfacher Cache-Schicht
+// ─────────────────────────────────────────────────────────────────────────────
+const SEARCH_CACHE_TTL = 5 * 60 * 1000; // 5 Minuten
+let toursSearchCache = { data: null, timestamp: 0 };
+
+async function loadToursSearchCache() {
+    const { rows } = await client.query(
+        `SELECT *
+         FROM (
+             SELECT
+                 t.id            AS tour_id,
+                 t.title         AS tour_title,
+                 t.tour_image    AS tour_image,
+                 ta.artist_id    AS artist_id,
+                 e.id            AS event_id,
+                 e.start_time    AS start_time,
+                 v.name          AS venue_name,
+                 c.name          AS city_name,
+                 ROW_NUMBER() OVER (PARTITION BY t.id ORDER BY e.start_time) AS rn
+             FROM tours t
+                  JOIN tour_artists ta ON ta.tour_id = t.id
+                  LEFT JOIN events e      ON e.tour_id = t.id
+                  LEFT JOIN venues v      ON v.id = e.venue_id
+                  LEFT JOIN cities c      ON c.id = v.city_id
+         ) sub
+         WHERE sub.rn <= 2 OR sub.event_id IS NULL
+         ORDER BY sub.tour_title, sub.rn;`
+    );
+
+    const map = {};
+    rows.forEach((r) => {
+        if (!map[r.tour_id]) {
+            map[r.tour_id] = {
+                id: r.tour_id,
+                title: r.tour_title,
+                tour_image: r.tour_image,
+                artist_id: r.artist_id,
+                events: [],
+            };
+        }
+        if (r.event_id && r.rn <= 2) {
+            map[r.tour_id].events.push({
+                id: r.event_id,
+                start_time: r.start_time,
+                venueName: r.venue_name,
+                cityName: r.city_name,
+            });
+        }
+    });
+
+    toursSearchCache = { data: Object.values(map), timestamp: Date.now() };
+}
+
+app.get('/search-tours', async (req, res) => {
+    const query = (req.query.q || '').toLowerCase();
+    if (!toursSearchCache.data || Date.now() - toursSearchCache.timestamp > SEARCH_CACHE_TTL) {
+        try {
+            await loadToursSearchCache();
+        } catch (err) {
+            console.error('Error loading search cache:', err);
+            return res.status(500).json({ message: 'Fehler beim Laden der Suchdaten' });
+        }
+    }
+
+    const result = toursSearchCache.data.filter((t) =>
+        t.title.toLowerCase().includes(query)
+    );
+    res.json({ tours: result.slice(0, 10) });
+});
+
 app.post('/create-area', async (req, res) => {
     try {
         const { name, description } = req.body;

--- a/eventim-disability-integration/src/components/nav-bar.jsx
+++ b/eventim-disability-integration/src/components/nav-bar.jsx
@@ -14,10 +14,14 @@ export default function NavBar() {
     const { items: cartItems, loading: cartLoading, reload: reloadCart } = useCart();
     const [showCheckoutModal, setShowCheckoutModal] = useState(false);
 
+    const [searchQuery, setSearchQuery] = useState('');
+    const [searchResults, setSearchResults] = useState([]);
+
     const eventsRef = useRef(null);
     const placesRef = useRef(null);
     const profileRef = useRef(null);
     const cartRef = useRef(null);
+    const searchRef = useRef(null);
 
     const { loading: authLoading, loggedIn, user } = useAuth();
 
@@ -28,6 +32,39 @@ export default function NavBar() {
             .then((body) => setGenres(body.genres))
             .catch((err) => console.error('Error loading genres:', err));
     }, []);
+
+    // Search tours on input
+    useEffect(() => {
+        const controller = new AbortController();
+        const q = searchQuery.trim();
+        if (!q) {
+            setSearchResults([]);
+            return;
+        }
+        const timeout = setTimeout(async () => {
+            try {
+                const res = await fetch(
+                    `${API_BASE_URL}/search-tours?q=${encodeURIComponent(q)}`,
+                    { signal: controller.signal }
+                );
+                if (res.ok) {
+                    const data = await res.json();
+                    setSearchResults(Array.isArray(data.tours) ? data.tours : []);
+                } else {
+                    setSearchResults([]);
+                }
+            } catch (err) {
+                if (err.name !== 'AbortError') {
+                    console.error('Search error:', err);
+                    setSearchResults([]);
+                }
+            }
+        }, 300);
+        return () => {
+            controller.abort();
+            clearTimeout(timeout);
+        };
+    }, [searchQuery]);
 
     // Load cities
     useEffect(() => {
@@ -44,7 +81,8 @@ export default function NavBar() {
                 eventsRef.current && !eventsRef.current.contains(e.target) &&
                 placesRef.current && !placesRef.current.contains(e.target) &&
                 profileRef.current && !profileRef.current.contains(e.target) &&
-                cartRef.current && !cartRef.current.contains(e.target)
+                cartRef.current && !cartRef.current.contains(e.target) &&
+                searchRef.current && !searchRef.current.contains(e.target)
             ) {
                 setOpenDropdown(null);
             }
@@ -149,8 +187,17 @@ export default function NavBar() {
                     </div>
                 </nav>
 
-                <div className="search">
-                    <input type="search" placeholder="Suche nach Künstlern und Events" />
+                <div className="search" ref={searchRef}>
+                    <input
+                        type="search"
+                        placeholder="Suche nach Touren"
+                        value={searchQuery}
+                        onChange={(e) => {
+                            setSearchQuery(e.target.value);
+                            if (!openDropdown) setOpenDropdown('search');
+                        }}
+                        onFocus={() => setOpenDropdown('search')}
+                    />
                     <div className="search-icon">
                         <Image
                             src="/pictures/search_icon.png"
@@ -159,6 +206,39 @@ export default function NavBar() {
                             height={20}
                         />
                     </div>
+                    {openDropdown === 'search' && (
+                        <div className="nav-search-results">
+                            {searchQuery.trim() && searchResults.length === 0 && (
+                                <div className="nav-search-no-results">Keine Ergebnisse</div>
+                            )}
+                            {searchResults.map((tour) => (
+                                <div key={tour.id} className="nav-search-item">
+                                    <a
+                                        href={`/artists/${tour.artist_id}/${tour.id}`}
+                                        className="search-tour-title"
+                                    >
+                                        {tour.title}
+                                    </a>
+                                    <div className="nav-search-events">
+                                        {tour.events.map((ev) => {
+                                            const dt = new Date(ev.start_time);
+                                            const ds = dt.toLocaleDateString('de-DE');
+                                            const ts = dt.toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
+                                            return (
+                                                <a
+                                                    key={ev.id}
+                                                    href={`/artists/${tour.artist_id}/${tour.id}/${ev.id}`}
+                                                    className="nav-search-event-link"
+                                                >
+                                                    {ds} {ts} – {ev.cityName}, {ev.venueName}
+                                                </a>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    )}
                 </div>
 
                 <div className="icons">

--- a/eventim-disability-integration/src/pages/_app.jsx
+++ b/eventim-disability-integration/src/pages/_app.jsx
@@ -14,6 +14,7 @@ import '../styles/footer.css';
 import '../styles/scroller.css';
 import '../styles/smallTourCard.css';
 import '../styles/navBar.css';
+import '../styles/search.css';
 import '../styles/events.css';
 import '../styles/checkout.css';
 import '../styles/404.css';

--- a/eventim-disability-integration/src/styles/search.css
+++ b/eventim-disability-integration/src/styles/search.css
@@ -1,0 +1,52 @@
+.nav-search-results {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+    max-height: 320px;
+    overflow-y: auto;
+    z-index: 1200;
+}
+
+.nav-search-item {
+    padding: 0.5rem 0.75rem;
+    border-bottom: 1px solid #eee;
+    cursor: pointer;
+}
+.nav-search-item:last-child {
+    border-bottom: none;
+}
+.nav-search-item:hover {
+    background-color: #f5f5f5;
+}
+
+.nav-search-item .search-tour-title {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+    color: #002b55;
+}
+
+.nav-search-events {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-left: 0.5rem;
+    font-size: 0.9rem;
+    color: #333;
+}
+
+.nav-search-event-link {
+    color: #005ea5;
+    text-decoration: none;
+}
+.nav-search-event-link:hover {
+    text-decoration: underline;
+}
+
+.nav-search-no-results {
+    padding: 0.5rem 0.75rem;
+    color: #555;
+}


### PR DESCRIPTION
## Summary
- implement search API with caching on the server
- add search bar interactions and dropdown results in the navbar
- style search results and import new stylesheet

## Testing
- `npm test --silent` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_6859510f4b60833082b11fa83310845c