### PR TITLE
Add capacity endpoint and dynamic labels

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -2241,6 +2241,47 @@ app.get('/event-details/:id', async (req, res) => {
     }
 });
 
+// Liefert verbleibende Kapazitäten pro Kategorie eines Events
+app.get('/event-capacities/:id', async (req, res) => {
+    const eventId = req.params.id;
+    try {
+        const { rows: catRows } = await client.query(
+            `SELECT ec.id,
+                    ec.disability_support_for,
+                    COALESCE(SUM(eva.capacity),0) AS capacity
+             FROM event_categories ec
+                  LEFT JOIN event_venue_areas eva ON eva.category_id = ec.id
+             WHERE ec.event_id = $1
+             GROUP BY ec.id, ec.disability_support_for`,
+            [eventId]
+        );
+
+        const categories = [];
+        for (const r of catRows) {
+            const { rows: soldRows } = await client.query(
+                'SELECT COUNT(*) AS sold FROM tickets WHERE event_category_id = $1',
+                [r.id]
+            );
+            const sold = parseInt(soldRows[0].sold, 10) || 0;
+            const capacity = parseInt(r.capacity, 10) || 0;
+            categories.push({
+                id: r.id,
+                disability_support_for: r.disability_support_for,
+                capacity,
+                remaining: capacity - sold,
+            });
+        }
+
+        const totalCapacity = categories.reduce((s, c) => s + c.capacity, 0);
+        const totalRemaining = categories.reduce((s, c) => s + c.remaining, 0);
+
+        return res.json({ eventId, totalCapacity, totalRemaining, categories });
+    } catch (err) {
+        console.error('Error in /event-capacities:', err);
+        return res.status(500).json({ message: 'Fehler beim Laden der Kapazität' });
+    }
+});
+
 // ── just after your session / client setup ──
 
 // Helper to find-or-create a cart

--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/index.jsx
@@ -2,13 +2,17 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { API_BASE_URL } from '../../../../config';
 import FilterBar from "../../../../components/filter-bar";
+import { useAuth } from '../../../../hooks/useAuth';
 
 export default function TourEventsPage() {
     const router = useRouter();
     const { artist, tour } = router.query;
 
+    const { loggedIn, user } = useAuth();
+
     const [tourData, setTourData] = useState(null);
     const [events, setEvents] = useState([]);
+    const [availability, setAvailability] = useState({});
 
     useEffect(() => {
         if (!tour) return;
@@ -28,6 +32,23 @@ export default function TourEventsPage() {
         };
         load();
     }, [tour]);
+
+    useEffect(() => {
+        if (events.length === 0) return;
+        const fetchCaps = async () => {
+            const map = {};
+            for (const ev of events) {
+                try {
+                    const res = await fetch(`${API_BASE_URL}/event-capacities/${ev.id}`);
+                    if (!res.ok) continue;
+                    const data = await res.json();
+                    map[ev.id] = data;
+                } catch {}
+            }
+            setAvailability(map);
+        };
+        fetchCaps();
+    }, [events]);
 
     if (!tourData) return <div>Loading …</div>;
 
@@ -84,6 +105,25 @@ export default function TourEventsPage() {
                     {events.map((ev) => {
                         const evUrl = `/artists/${artist}/${tour}/${ev.id}`;
                         const evAcc = Array.from(new Set(ev.accessibility || []));
+
+                        const info = availability[ev.id];
+                        let soldOut = false;
+                        let limited = false;
+                        if (info) {
+                            const totalCap = info.totalCapacity || 0;
+                            const totalRem = info.totalRemaining || 0;
+                            let userRem = 0;
+                            if (info.categories) {
+                                info.categories.forEach((c) => {
+                                    const code = c.disability_support_for && c.disability_support_for.trim();
+                                    const canBook = !code || (loggedIn && user?.disabilityCheck && (user.disabilityMarks || []).includes(code));
+                                    if (canBook) userRem += c.remaining;
+                                });
+                            }
+                            soldOut = userRem <= 0;
+                            limited = !soldOut && totalCap > 0 && totalRem / totalCap <= 0.2;
+                        }
+
                         return (
                             <div className="artist-card" key={ev.id}>
                                 <div className="card-body">
@@ -113,15 +153,21 @@ export default function TourEventsPage() {
                                                     </div>
                                                 )}
                                             </div>
-                                            <div className="no-availability-message">
-                                                Das Event ist ausverkauft!
-                                            </div>
-                                            <div className="availability-limited-message">
-                                                Es sind nur noch weniger als 20% der Tickets verfügbar!
-                                            </div>
-                                            <div className="availability-message">
-                                                Tickets stehen zur Verfügung!
-                                            </div>
+                                            {soldOut && (
+                                                <div className="no-availability-message">
+                                                    Das Event ist ausverkauft!
+                                                </div>
+                                            )}
+                                            {!soldOut && limited && (
+                                                <div className="availability-limited-message">
+                                                    Es sind nur noch weniger als 20% der Tickets verfügbar!
+                                                </div>
+                                            )}
+                                            {!soldOut && !limited && (
+                                                <div className="availability-message">
+                                                    Tickets stehen zur Verfügung!
+                                                </div>
+                                            )}
 
                                             <div className="header-right">
                                                 <button
@@ -130,25 +176,11 @@ export default function TourEventsPage() {
                                                         e.stopPropagation();
                                                         router.push(evUrl);
                                                     }}
+                                                    style={soldOut ? { backgroundColor: 'lightgrey' } : undefined}
+                                                    disabled={soldOut}
                                                 >
                                                     Tickets
                                                 </button>
-                                                <button
-                                                    className="btn-view-events"
-                                                    onClick={(e) => {
-                                                        e.stopPropagation();
-                                                        router.push(evUrl);
-                                                    }}
-                                                    style={{backgroundColor: 'lightgrey'}}
-                                                >
-                                                    Tickets (but diabled)
-                                                </button>
-                                                Here, your task is to implement that only one of the labels above is displayed depending on the capacity of the event.
-                                                For that event, the total capacity of all event_categories should be looked at (total of all event_category capacities)
-                                                If it hits 20% rest capacity the orange label should be displayed if all event_categories that are bookable for that person are 0 the red label should be displayed.
-                                                Sometimes, if the user is disabled and can book more categories, the label shows 20% whereas for regular users it shows sold out.
-                                                If the red label is presented, the ticket label should be displayed as grey.
-                                                You can get the current capacity by counting the total tickets for that event for that event_category and substracting that from the total of that event_category.
                                             </div>
                                         </div>
                                     </div>


### PR DESCRIPTION
## Summary
- add backend API `/event-capacities/:id` to expose remaining tickets per event category
- fetch capacity data in the tour events page and compute availability per event
- show the correct availability label and disable Tickets button when sold out

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685beef24dc483309db90978dba57ff4