### PR TITLE
Add disability card back and expiry fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,14 +171,17 @@ classDiagram
     varchar(255) email
     varchar(20) phone
     date birth_date
-    boolean disability_check
+    boolean request_for_disability
     integer disability_degree
-    uuid disability_card_image
+    uuid disability_card_image_front
     timestamp with time zone created_at
     timestamp with time zone updated_at
     text password
+    uuid disability_card_image_back
+    boolean is_currently_disabled
+    date disability_card_expiry_date
     uuid user_id
- }
+}
  class venue_areas {
     uuid venue_id
     integer max_capacity

--- a/eventim-disability-integration/server/database_schema.md
+++ b/eventim-disability-integration/server/database_schema.md
@@ -195,12 +195,15 @@ class users {
    varchar(255) email
    varchar(20) phone
    date birth_date
-   boolean disability_check
+   boolean request_for_disability
    integer disability_degree
-   uuid disability_card_image
+   uuid disability_card_image_front
    timestamp with time zone created_at
    timestamp with time zone updated_at
    text password
+   uuid disability_card_image_back
+   boolean is_currently_disabled
+   date disability_card_expiry_date
    uuid user_id
 }
 class venue_areas {

--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -76,7 +76,10 @@ app.get('/image/:id', async (req, res) => {
 //     const multer = require('multer');
 //     const upload = multer({ storage: multer.memoryStorage() });
 
-app.post('/register-user', upload.single('disabilityCardImage'), async (req, res) => {
+app.post('/register-user', upload.fields([
+    { name: 'disabilityCardImageFront', maxCount: 1 },
+    { name: 'disabilityCardImageBack', maxCount: 1 }
+]), async (req, res) => {
     try {
         const {
             firstName,
@@ -87,6 +90,8 @@ app.post('/register-user', upload.single('disabilityCardImage'), async (req, res
             phone,
             disabilityCheck,
             disabilityDegree,
+            disabilityCardExpiryDate,
+            isCurrentlyDisabled,
             streetAddress,
             city,
             postalCode,
@@ -117,14 +122,25 @@ app.post('/register-user', upload.single('disabilityCardImage'), async (req, res
         const saltRounds = 10;
         const hashedPass = await bcrypt.hash(password, saltRounds);
 
-        // 5) Behindertenausweis‐Bild verarbeiten (falls vorhanden)
-        let imageId = null;
-        if (req.file) {
-            imageId = uuidv4();
+        // 5) Behindertenausweis-Bilder verarbeiten (falls vorhanden)
+        let imageFrontId = null;
+        let imageBackId = null;
+        if (req.files && req.files['disabilityCardImageFront']) {
+            const f = req.files['disabilityCardImageFront'][0];
+            imageFrontId = uuidv4();
             await client.query(
                 `INSERT INTO images (id, image_data, image_type, entity_type, entity_id)
                  VALUES ($1, $2, $3, $4, $5)`,
-                [imageId, req.file.buffer, req.file.mimetype, 'user', userId]
+                [imageFrontId, f.buffer, f.mimetype, 'user', userId]
+            );
+        }
+        if (req.files && req.files['disabilityCardImageBack']) {
+            const b = req.files['disabilityCardImageBack'][0];
+            imageBackId = uuidv4();
+            await client.query(
+                `INSERT INTO images (id, image_data, image_type, entity_type, entity_id)
+                 VALUES ($1, $2, $3, $4, $5)`,
+                [imageBackId, b.buffer, b.mimetype, 'user', userId]
             );
         }
 
@@ -147,13 +163,16 @@ app.post('/register-user', upload.single('disabilityCardImage'), async (req, res
                     country,
                     company,
                     salutation,
-                    disability_card_image,
+                    disability_card_image_front,
+                    disability_card_image_back,
+                    disability_card_expiry_date,
+                    is_currently_disabled,
                     created_at,
                     updated_at
                 ) VALUES (
-                             $1, $2, $3, $4, $5, $6, $7, $8, $9,
-                             $10, $11, $12, $13, $14, $15, $16, NOW(), NOW()
-                         ) RETURNING *;
+                    $1, $2, $3, $4, $5, $6, $7, $8, $9,
+                    $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, NOW(), NOW()
+                ) RETURNING *;
             `,
             [
                 userId,
@@ -171,7 +190,10 @@ app.post('/register-user', upload.single('disabilityCardImage'), async (req, res
                 country?.trim() || 'Deutschland',
                 company?.trim() || null,
                 salutation?.trim() || null,
-                imageId,
+                imageFrontId,
+                imageBackId,
+                disabilityCardExpiryDate || '9999-01-01',
+                isCurrentlyDisabled === 'true',
             ]
         );
 

--- a/eventim-disability-integration/src/pages/profile/index.jsx
+++ b/eventim-disability-integration/src/pages/profile/index.jsx
@@ -78,7 +78,10 @@ export default function ProfilePage() {
     });
 
     const [disabilityDegree, setDisabilityDegree] = useState('');
-    const [disabilityCardImage, setDisabilityCardImage] = useState(null);
+    const [disabilityCardImageFront, setDisabilityCardImageFront] = useState(null);
+    const [disabilityCardImageBack, setDisabilityCardImageBack] = useState(null);
+    const [disabilityCardExpiryDate, setDisabilityCardExpiryDate] = useState('9999-01-01');
+    const [hasExpiry, setHasExpiry] = useState(false);
     const [marks, setMarks] = useState([]);
     const [selectedMarks, setSelectedMarks] = useState([]);
     const [showDisabilityForm, setShowDisabilityForm] = useState(false);
@@ -271,8 +274,13 @@ export default function ProfilePage() {
         const fd = new FormData();
         fd.append('disabilityCheck', true);
         fd.append('disabilityDegree', disabilityDegree);
-        if (disabilityCardImage) {
-            fd.append('disabilityCardImage', disabilityCardImage);
+        fd.append('disabilityCardExpiryDate', disabilityCardExpiryDate);
+        fd.append('isCurrentlyDisabled', false);
+        if (disabilityCardImageFront) {
+            fd.append('disabilityCardImageFront', disabilityCardImageFront);
+        }
+        if (disabilityCardImageBack) {
+            fd.append('disabilityCardImageBack', disabilityCardImageBack);
         }
         fd.append('disabilityMarks', JSON.stringify(selectedMarks));
         try {
@@ -732,8 +740,44 @@ export default function ProfilePage() {
                                                     <input type="number" id="disabilityDegree" value={disabilityDegree} onChange={e => setDisabilityDegree(e.target.value)} min="0" max="100" />
                                                 </div>
                                                 <div className="form-field">
-                                                    <label htmlFor="disabilityCardImage">Behindertenausweis hochladen</label>
-                                                    <input type="file" id="disabilityCardImage" onChange={e => setDisabilityCardImage(e.target.files[0])} />
+                                                    <label htmlFor="disabilityCardImageFront">Behindertenausweis hochladen (Vorderseite)</label>
+                                                    <input type="file" id="disabilityCardImageFront" onChange={e => setDisabilityCardImageFront(e.target.files[0])} />
+                                                </div>
+                                                <div className="form-field">
+                                                    <label htmlFor="disabilityCardImageBack">Behindertenausweis hochladen (Rückseite)</label>
+                                                    <input type="file" id="disabilityCardImageBack" onChange={e => setDisabilityCardImageBack(e.target.files[0])} />
+                                                </div>
+                                                <div className="form-field" style={{ gridColumn: 'span 2' }}>
+                                                    <label>Gültigkeit des Ausweises</label>
+                                                    <div>
+                                                        <input
+                                                            type="checkbox"
+                                                            id="hasExpiryProfile"
+                                                            checked={hasExpiry}
+                                                            onChange={(e) => {
+                                                                setHasExpiry(e.target.checked);
+                                                                if (!e.target.checked) {
+                                                                    setDisabilityCardExpiryDate('9999-01-01');
+                                                                } else {
+                                                                    const t = new Date().toISOString().split('T')[0];
+                                                                    setDisabilityCardExpiryDate(t);
+                                                                }
+                                                            }}
+                                                            style={{ marginRight: '0.5rem' }}
+                                                        />
+                                                        <label htmlFor="hasExpiryProfile" style={{ fontWeight: 'bold' }}>
+                                                            {hasExpiry ? 'befristet' : 'unbefristet'}
+                                                        </label>
+                                                    </div>
+                                                    {hasExpiry && (
+                                                        <input
+                                                            type="date"
+                                                            id="disabilityCardExpiryDateProfile"
+                                                            value={disabilityCardExpiryDate}
+                                                            onChange={e => setDisabilityCardExpiryDate(e.target.value)}
+                                                            style={{ marginTop: '0.5rem' }}
+                                                        />
+                                                    )}
                                                 </div>
                                                 <div className="form-field">
                                                     <label>Grad der Behinderung – Markierungen</label>

--- a/eventim-disability-integration/src/pages/registration.jsx
+++ b/eventim-disability-integration/src/pages/registration.jsx
@@ -17,7 +17,10 @@ export default function Registration() {
         phone: '',
         disabilityCheck: false,
         disabilityDegree: '',
-        disabilityCardImage: null,
+        disabilityCardImageFront: null,
+        disabilityCardImageBack: null,
+        disabilityCardExpiryDate: '9999-01-01',
+        isCurrentlyDisabled: false,
         streetAddress: '',
         city: '',
         postalCode: '',
@@ -25,6 +28,8 @@ export default function Registration() {
         company: '',
         salutation: '',
     });
+
+    const [hasExpiry, setHasExpiry] = useState(false);
 
     // Holds all marks fetched from server:
     const [disabilityMarks, setDisabilityMarks] = useState([]);
@@ -84,7 +89,8 @@ export default function Registration() {
                     ? {}
                     : {
                         disabilityDegree: '',
-                        disabilityCardImage: null,
+                        disabilityCardImageFront: null,
+                        disabilityCardImageBack: null,
                         // Clear any mark‐checkboxes if user unticks “I have a card”
                         selectedMarks: [],
                     }),
@@ -115,6 +121,22 @@ export default function Registration() {
         });
     };
 
+    const handleExpiryToggle = (checked) => {
+        setHasExpiry(checked);
+        if (!checked) {
+            setFormData(prev => ({
+                ...prev,
+                disabilityCardExpiryDate: '9999-01-01',
+            }));
+        } else {
+            const today = new Date().toISOString().split('T')[0];
+            setFormData(prev => ({
+                ...prev,
+                disabilityCardExpiryDate: today,
+            }));
+        }
+    };
+
     const handleSubmit = async (e) => {
         e.preventDefault();
         setLoading(true);
@@ -130,16 +152,17 @@ export default function Registration() {
         try {
             // Build FormData
             const payload = new FormData();
-            // Append all existing simple fields except file and except we’ll handle marks separately
+            // Append all existing simple fields except files; handle marks separately
             Object.keys(formData).forEach((key) => {
-                // We’ll append the file later. Also skip disabilityCardImage if null
-                if (key === 'disabilityCardImage') return;
+                if (key === 'disabilityCardImageFront' || key === 'disabilityCardImageBack') return;
                 payload.append(key, formData[key]);
             });
 
-            // Append the file if present
-            if (formData.disabilityCardImage) {
-                payload.append('disabilityCardImage', formData.disabilityCardImage);
+            if (formData.disabilityCardImageFront) {
+                payload.append('disabilityCardImageFront', formData.disabilityCardImageFront);
+            }
+            if (formData.disabilityCardImageBack) {
+                payload.append('disabilityCardImageBack', formData.disabilityCardImageBack);
             }
 
             // Append the selected marks as a JSON string
@@ -483,18 +506,18 @@ export default function Registration() {
                             />
                         </div>
 
-                        {/* Behindertenausweis hochladen */}
+                        {/* Behindertenausweis Vorderseite hochladen */}
                         <div style={{ marginBottom: '1rem' }}>
                             <label
-                                htmlFor="disabilityCardImage"
+                                htmlFor="disabilityCardImageFront"
                                 style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 'bold' }}
                             >
-                                Behindertenausweis hochladen
+                                Behindertenausweis hochladen (Vorderseite)
                             </label>
                             <input
                                 type="file"
-                                id="disabilityCardImage"
-                                name="disabilityCardImage"
+                                id="disabilityCardImageFront"
+                                name="disabilityCardImageFront"
                                 onChange={handleChange}
                                 style={{
                                     width: '100%',
@@ -503,6 +526,63 @@ export default function Registration() {
                                     border: '1px solid #ccc',
                                 }}
                             />
+                        </div>
+
+                        {/* Behindertenausweis Rückseite hochladen */}
+                        <div style={{ marginBottom: '1rem' }}>
+                            <label
+                                htmlFor="disabilityCardImageBack"
+                                style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 'bold' }}
+                            >
+                                Behindertenausweis hochladen (Rückseite)
+                            </label>
+                            <input
+                                type="file"
+                                id="disabilityCardImageBack"
+                                name="disabilityCardImageBack"
+                                onChange={handleChange}
+                                style={{
+                                    width: '100%',
+                                    padding: '0.5rem',
+                                    borderRadius: '4px',
+                                    border: '1px solid #ccc',
+                                }}
+                            />
+                        </div>
+
+                        {/* Befristung des Ausweises */}
+                        <div style={{ marginBottom: '1rem' }}>
+                            <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 'bold' }}>
+                                Gültigkeit des Ausweises
+                            </label>
+                            <div>
+                                <input
+                                    type="checkbox"
+                                    id="hasExpiry"
+                                    checked={hasExpiry}
+                                    onChange={(e) => handleExpiryToggle(e.target.checked)}
+                                    style={{ marginRight: '0.5rem' }}
+                                />
+                                <label htmlFor="hasExpiry" style={{ fontWeight: 'bold' }}>
+                                    {hasExpiry ? 'befristet' : 'unbefristet'}
+                                </label>
+                            </div>
+                            {hasExpiry && (
+                                <input
+                                    type="date"
+                                    id="disabilityCardExpiryDate"
+                                    name="disabilityCardExpiryDate"
+                                    value={formData.disabilityCardExpiryDate}
+                                    onChange={handleChange}
+                                    style={{
+                                        width: '100%',
+                                        padding: '0.5rem',
+                                        borderRadius: '4px',
+                                        border: '1px solid #ccc',
+                                        marginTop: '0.5rem',
+                                    }}
+                                />
+                            )}
                         </div>
 
                         {/* ---------------- Grad der Behinderung: Auswahl der Markierungen ---------------- */}


### PR DESCRIPTION
## Summary
- collect front and back images and expiry date on registration
- allow uploading disability card back and expiry info in profile
- store new data on user registration
- document updated `users` table in README and database schema

## Testing
- `CI=true npm test --silent` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_685c0bc71990833084ce7dd2c70ee77b