### PR TITLE
Add venue images and event titles

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -840,14 +840,22 @@ app.get('/areas', async (req, res) => {
 });
 
 // POST: Venue erstellen (inkl. area capacities)
-app.post('/create-venue', express.json(), async (req, res) => {
+app.post('/create-venue', upload.single('venueImage'), async (req, res) => {
     const {
         name,
         address,
         cityId,
         website,
-        venueAreas = [],
+        venueAreasJson = '[]',
     } = req.body;
+
+    let venueAreas = [];
+    try {
+        venueAreas = JSON.parse(venueAreasJson);
+        if (!Array.isArray(venueAreas)) venueAreas = [];
+    } catch {
+        venueAreas = [];
+    }
 
     if (!name?.trim() || !address?.trim() || !cityId) {
         return res.status(400).json({
@@ -859,12 +867,21 @@ app.post('/create-venue', express.json(), async (req, res) => {
         await client.query('BEGIN');
         const venueId = uuidv4();
 
+        let imageId = null;
+        if (req.file) {
+            imageId = uuidv4();
+            await client.query(
+                'INSERT INTO images (id, image_data, image_type, entity_type, entity_id) VALUES ($1,$2,$3,$4,$5)',
+                [imageId, req.file.buffer, req.file.mimetype, 'venue', venueId]
+            );
+        }
+
         const { rows } = await client.query(
             `INSERT INTO venues
-                 (id, name, address, city_id, website)
-             VALUES ($1,$2,$3,$4,$5)
+                 (id, name, address, city_id, website, venue_image)
+             VALUES ($1,$2,$3,$4,$5,$6)
              RETURNING *`,
-            [venueId, name.trim(), address.trim(), cityId, website || null]
+            [venueId, name.trim(), address.trim(), cityId, website || null, imageId]
         );
 
         for (const va of venueAreas) {
@@ -930,6 +947,7 @@ app.get('/venues-detailed', async (req, res) => {
                     v.address,
                     v.city_id    AS "cityId",
                     v.website,
+                    v.venue_image,
                     c.name       AS city_name
              FROM venues v
                       LEFT JOIN cities c ON c.id = v.city_id
@@ -1227,7 +1245,8 @@ app.get('/cities-with-venues', async (req, res) => {
           json_agg(
             json_build_object(
               'id', v.id,
-              'name', v.name
+              'name', v.name,
+              'venue_image', v.venue_image
             )
           ) FILTER (WHERE v.id IS NOT NULL),
           '[]'

--- a/eventim-disability-integration/src/components/nav-bar.jsx
+++ b/eventim-disability-integration/src/components/nav-bar.jsx
@@ -143,10 +143,16 @@ export default function NavBar() {
                         <div className="dropdown-menu">
                             {genres.map((g) => (
                                 <div key={g.id} className="dropdown-item">
-                                    <span className="label">{g.name}</span>
+                                    <a href={`/genres/${g.id}`} className="label">
+                                        {g.name}
+                                    </a>
                                     <div className="sub-menu">
                                         {g.subgenres.map((s) => (
-                                            <a key={s.id} href="#" className="dropdown-item">
+                                            <a
+                                                key={s.id}
+                                                href={`/genres/${g.id}/${s.id}`}
+                                                className="dropdown-item"
+                                            >
                                                 {s.name}
                                             </a>
                                         ))}
@@ -173,10 +179,16 @@ export default function NavBar() {
                         <div className="dropdown-menu">
                             {cities.map((c) => (
                                 <div key={c.id} className="dropdown-item">
-                                    <span className="label">{c.name}</span>
+                                    <a href={`/locations/${c.id}`} className="label">
+                                        {c.name}
+                                    </a>
                                     <div className="sub-menu">
                                         {c.venues.map((v) => (
-                                            <a key={v.id} href="#" className="dropdown-item">
+                                            <a
+                                                key={v.id}
+                                                href={`/locations/${c.id}/${v.id}`}
+                                                className="dropdown-item"
+                                            >
                                                 {v.name}
                                             </a>
                                         ))}

--- a/eventim-disability-integration/src/pages/admin/venues/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/create.jsx
@@ -8,7 +8,8 @@ export default function VenueCreation() {
         name: '',
         address: '',
         cityId: '',
-        website: ''
+        website: '',
+        venueImage: null
     });
     const [cities, setCities] = useState([]);
     const [areas, setAreas] = useState([]);
@@ -24,8 +25,12 @@ export default function VenueCreation() {
     }, []);
 
     const handleChange = e => {
-        const { name, value } = e.target;
-        setFormData(f => ({ ...f, [name]: value }));
+        const { name, value, files, type } = e.target;
+        if (type === 'file') {
+            setFormData(f => ({ ...f, [name]: files[0] }));
+        } else {
+            setFormData(f => ({ ...f, [name]: value }));
+        }
     };
 
     const addArea = () => {
@@ -56,19 +61,23 @@ export default function VenueCreation() {
         }
 
         try {
-            const payload = {
-                ...formData,
-                venueAreas
-            };
+            const fd = new FormData();
+            fd.append('name', formData.name.trim());
+            fd.append('address', formData.address.trim());
+            fd.append('cityId', formData.cityId);
+            fd.append('website', formData.website || '');
+            fd.append('venueAreasJson', JSON.stringify(venueAreas));
+            if (formData.venueImage) {
+                fd.append('venueImage', formData.venueImage);
+            }
             const res = await fetch('http://localhost:4000/create-venue', {
                 method:'POST',
-                headers:{ 'Content-Type':'application/json' },
-                body: JSON.stringify(payload)
+                body: fd
             });
             const data = await res.json();
             if (res.ok) {
                 setMessage(`Venue „${data.venue.name}“ erstellt`);
-                setFormData({ name:'', address:'', cityId:'', website:'' });
+                setFormData({ name:'', address:'', cityId:'', website:'', venueImage:null });
                 setVenueAreas([]);
             } else {
                 setMessage(data.message || 'Fehler beim Erstellen');
@@ -126,6 +135,17 @@ export default function VenueCreation() {
                     <input id="website" name="website" type="url" value={formData.website}
                            onChange={handleChange} placeholder="https://example.com"
                            style={{ width:'100%', padding:'.5rem', borderRadius:'4px', border:'1px solid #ccc' }}
+                    />
+                </div>
+                {/* Venue Image */}
+                <div style={{ marginBottom:'1rem' }}>
+                    <label htmlFor="venueImage" style={{ display:'block', fontWeight:'bold', marginBottom:'.5rem' }}>Bild hochladen</label>
+                    <input
+                        id="venueImage"
+                        name="venueImage"
+                        type="file"
+                        onChange={handleChange}
+                        style={{ width:'100%', padding:'.5rem', borderRadius:'4px', border:'1px solid #ccc' }}
                     />
                 </div>
                 {/* Areas */}

--- a/eventim-disability-integration/src/pages/locations/[city]/[venue]/index.jsx
+++ b/eventim-disability-integration/src/pages/locations/[city]/[venue]/index.jsx
@@ -33,7 +33,13 @@ export default function VenueEventsPage() {
                 tours.forEach((t) => {
                     (t.events || []).forEach((ev) => {
                         if (ev.cityName === c.name && ev.venueName === v.name) {
-                            evs.push({ ...ev, tourId: t.id, artistIds: t.artistIds });
+                            evs.push({
+                                ...ev,
+                                tourId: t.id,
+                                artistIds: t.artistIds,
+                                tourTitle: t.title,
+                                tourImage: t.tour_image,
+                            });
                         }
                     });
                 });
@@ -143,18 +149,20 @@ export default function VenueEventsPage() {
                                             <img
                                                 className="artist-image"
                                                 src={
-                                                    eventData.tourImage
-                                                        ? `${API_BASE_URL}/image/${eventData.tourImage}`
+                                                    ev.tourImage
+                                                        ? `${API_BASE_URL}/image/${ev.tourImage}`
                                                         : '/pictures/placeholder.png'
                                                 }
-                                                alt={ev.tourName || 'Tour'}
-                                                style={{maxWidth:'120px'}}
+                                                alt={ev.tourTitle || 'Tour'}
+                                                style={{ maxWidth: '120px' }}
                                             />
-                                            Instead of the placeholder picture the picture of the events tour should be displayed before each entry, also the image and the title should be displayed on the left side and the label ans Tickets button on the right, so that the gap is in the middle
                                             <div>
                                                 <h3 className="tour-title">
-                                                    {formatDate(ev.start_time)} | {ev.cityName}
+                                                    {ev.tourTitle}
                                                 </h3>
+                                                <div className="tour-meta">
+                                                    <span>{formatDate(ev.start_time)} | {ev.cityName}</span>
+                                                </div>
                                                 <div className="tour-meta">
                                                     <span>{formatTime(ev.start_time)}</span>
                                                     <span> • {ev.venueName}</span>

--- a/eventim-disability-integration/src/pages/locations/[city]/index.jsx
+++ b/eventim-disability-integration/src/pages/locations/[city]/index.jsx
@@ -70,10 +70,19 @@ export default function CityPage() {
             tours.forEach((t) => {
                 (t.events || []).forEach((ev) => {
                     if (ev.cityName === cityData.name && ev.venueName === v.name) {
-                        if (cheapest == null || (t.cheapestPrice != null && t.cheapestPrice < cheapest)) {
+                        if (
+                            cheapest == null ||
+                            (t.cheapestPrice != null && t.cheapestPrice < cheapest)
+                        ) {
                             cheapest = t.cheapestPrice;
                         }
-                        vEvents.push({ ...ev, tourId: t.id, artistIds: t.artistIds });
+                        vEvents.push({
+                            ...ev,
+                            tourId: t.id,
+                            artistIds: t.artistIds,
+                            tourTitle: t.title,
+                            tourImage: t.tour_image,
+                        });
                     }
                 });
             });
@@ -87,6 +96,7 @@ export default function CityPage() {
                 events: vEvents,
                 eventCount: vEvents.length,
                 cheapestPrice: cheapest,
+                venueImage: v.venue_image,
             };
         });
         setBasicFilteredVenues(arr);
@@ -227,7 +237,11 @@ export default function CityPage() {
                                     <div className="image-wrapper tour-image-large">
                                         <img
                                             className="artist-image"
-                                            src={'/pictures/placeholder.png'}
+                                            src={
+                                                sg.venueImage
+                                                    ? `${API_BASE_URL}/image/${sg.venueImage}`
+                                                    : '/pictures/placeholder.png'
+                                            }
                                             alt={sg.title}
                                         />
                                     </div>
@@ -283,13 +297,22 @@ export default function CityPage() {
                                                             className="sub-event-row hoverable"
                                                             onClick={() => router.push(evUrl)}
                                                         >
-                                                            <div className="sub-event-info">
+                                                            <div className="sub-event-info" style={{display:'flex',gap:'0.5rem',alignItems:'center'}}>
+                                                                <img
+                                                                    src={
+                                                                        ev.tourImage
+                                                                            ? `${API_BASE_URL}/image/${ev.tourImage}`
+                                                                            : '/pictures/placeholder.png'
+                                                                    }
+                                                                    alt={ev.tourTitle || 'Event'}
+                                                                    style={{width:'40px',height:'40px',objectFit:'cover'}}
+                                                                />
                                                                 <div className="sub-event-details">
-                                                                    <h3>ADD THE TOUR TITLE HERE</h3>
+                                                                    <h3>{ev.tourTitle}</h3>
                                                                 </div>
-                                                                <div className="sub-event-details">
-                                                                    {ev.cityName}, {ds}, {ts}
-                                                                </div>
+                                                            <div className="sub-event-details">
+                                                                {ev.cityName}, {ds}, {ts}
+                                                            </div>
                                                                 <div className="sub-event-arena">{ev.venueName}</div>
                                                                 {evAcc.length > 0 && (
                                                                     <div className="sub-event-accessibility">


### PR DESCRIPTION
## Summary
- store uploaded venue images and return them in venue queries
- support uploading venue images in admin UI
- show venue and event images on location pages
- display event titles in venue and city pages
- link dropdowns in nav bar to genre and location pages

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d15463b7883309ddb54c44ec764b6