### PR TITLE
Fix UI links and backend parsing

### DIFF
--- a/eventim-disability-integration/server/db.js
+++ b/eventim-disability-integration/server/db.js
@@ -24,9 +24,13 @@ async function reconnect() {
 
 async function query(text, params) {
     for (let attempt = 0; attempt < 2; attempt++) {
+        const client = await pool.connect();
         try {
-            return await pool.query(text, params);
+            const res = await client.query(text, params);
+            client.release();
+            return res;
         } catch (err) {
+            client.release();
             if (attempt === 0 && isConnectionError(err)) {
                 console.error('Database query failed, reconnecting...', err.message);
                 await reconnect();
@@ -35,6 +39,10 @@ async function query(text, params) {
             throw err;
         }
     }
+}
+
+async function getClient() {
+    return pool.connect();
 }
 
 async function healthCheck() {
@@ -48,4 +56,4 @@ async function healthCheck() {
 
 setInterval(healthCheck, 10000);
 
-module.exports = { query };
+module.exports = { query, getClient };

--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -841,13 +841,14 @@ app.get('/areas', async (req, res) => {
 
 // POST: Venue erstellen (inkl. area capacities)
 app.post('/create-venue', upload.single('venueImage'), async (req, res) => {
-    const {
-        name,
-        address,
-        cityId,
-        website,
-        venueAreas = [],
-    } = req.body;
+    let { name, address, cityId, website, venueAreas = [] } = req.body;
+    if (typeof venueAreas === 'string') {
+        try {
+            venueAreas = JSON.parse(venueAreas);
+        } catch (_) {
+            venueAreas = [];
+        }
+    }
 
     if (!name?.trim() || !address?.trim() || !cityId) {
         return res.status(400).json({

--- a/eventim-disability-integration/src/components/nav-bar.jsx
+++ b/eventim-disability-integration/src/components/nav-bar.jsx
@@ -143,7 +143,9 @@ export default function NavBar() {
                         <div className="dropdown-menu">
                             {genres.map((g) => (
                                 <div key={g.id} className="dropdown-item">
-                                    <span className="label">{g.name}</span>
+                                    <a href={`/genres/${g.id}`} className="label">
+                                        {g.name}
+                                    </a>
                                     <div className="sub-menu">
                                         {g.subgenres.map((s) => (
                                             <a
@@ -177,7 +179,9 @@ export default function NavBar() {
                         <div className="dropdown-menu">
                             {cities.map((c) => (
                                 <div key={c.id} className="dropdown-item">
-                                    <span className="label">{c.name}</span>
+                                    <a href={`/locations/${c.id}`} className="label">
+                                        {c.name}
+                                    </a>
                                     <div className="sub-menu">
                                         {c.venues.map((v) => (
                                             <a

--- a/eventim-disability-integration/src/pages/genres/[genre]/index.jsx
+++ b/eventim-disability-integration/src/pages/genres/[genre]/index.jsx
@@ -294,20 +294,34 @@ export default function GenrePage() {
                                                             className="sub-event-row hoverable"
                                                             onClick={() => router.push(evUrl)}
                                                         >
-                                                            <div className="sub-event-info">
-                                                                <div className="sub-event-details">
-                                                                    {ev.cityName}, {ds}, {ts}
-                                                                </div>
-                                                                <div className="sub-event-arena">{ev.venueName}</div>
-                                                                {evAcc.length > 0 && (
-                                                                    <div className="sub-event-accessibility">
-                                                                        {evAcc.map((lbl) => (
-                                                                            <span key={lbl} className="access-label-small">
-                                                                                {lbl}
-                                                                            </span>
-                                                                        ))}
+                                                            <div
+                                                                className="sub-event-info"
+                                                                style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}
+                                                            >
+                                                                <img
+                                                                    src={
+                                                                        ev.tourImage
+                                                                            ? `${API_BASE_URL}/image/${ev.tourImage}`
+                                                                            : '/pictures/placeholder.png'
+                                                                    }
+                                                                    alt={ev.tourTitle || 'Tour'}
+                                                                    style={{ width: '60px' }}
+                                                                />
+                                                                <div style={{ display: 'flex', flexDirection: 'column' }}>
+                                                                    <div className="sub-event-details">
+                                                                        {ev.cityName}, {ds}, {ts}
                                                                     </div>
-                                                                )}
+                                                                    <div className="sub-event-arena">{ev.venueName}</div>
+                                                                    {evAcc.length > 0 && (
+                                                                        <div className="sub-event-accessibility">
+                                                                            {evAcc.map((lbl) => (
+                                                                                <span key={lbl} className="access-label-small">
+                                                                                    {lbl}
+                                                                                </span>
+                                                                            ))}
+                                                                        </div>
+                                                                    )}
+                                                                </div>
                                                             </div>
                                                             <button
                                                                 className="btn-tickets"

--- a/eventim-disability-integration/src/pages/locations/[city]/index.jsx
+++ b/eventim-disability-integration/src/pages/locations/[city]/index.jsx
@@ -297,7 +297,10 @@ export default function CityPage() {
                                                             className="sub-event-row hoverable"
                                                             onClick={() => router.push(evUrl)}
                                                         >
-                                                            <div className="sub-event-info" style={{display:'flex',alignItems:'center',gap:'0.5rem'}}>
+                                                            <div
+                                                                className="sub-event-info"
+                                                                style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}
+                                                            >
                                                                 <img
                                                                     src={
                                                                         ev.tourImage
@@ -307,22 +310,21 @@ export default function CityPage() {
                                                                     alt={ev.tourTitle || 'Tour'}
                                                                     style={{ width: '60px' }}
                                                                 />
-                                                                <div className="sub-event-details">
-                                                                    <h3>{ev.tourTitle}</h3>
-                                                                </div>
-                                                                <div className="sub-event-details">
-                                                                    {ev.cityName}, {ds}, {ts}
-                                                                </div>
-                                                                <div className="sub-event-arena">{ev.venueName}</div>
-                                                                {evAcc.length > 0 && (
-                                                                    <div className="sub-event-accessibility">
-                                                                        {evAcc.map((lbl) => (
-                                                                            <span key={lbl} className="access-label-small">
-                                                                                {lbl}
-                                                                            </span>
-                                                                        ))}
+                                                                <div style={{ display: 'flex', flexDirection: 'column' }}>
+                                                                    <div className="sub-event-details">
+                                                                        {ev.cityName}, {ds}, {ts}
                                                                     </div>
-                                                                )}
+                                                                    <div className="sub-event-arena">{ev.venueName}</div>
+                                                                    {evAcc.length > 0 && (
+                                                                        <div className="sub-event-accessibility">
+                                                                            {evAcc.map((lbl) => (
+                                                                                <span key={lbl} className="access-label-small">
+                                                                                    {lbl}
+                                                                                </span>
+                                                                            ))}
+                                                                        </div>
+                                                                    )}
+                                                                </div>
                                                             </div>
                                                             <button
                                                                 className="btn-tickets"


### PR DESCRIPTION
## Summary
- make genres and cities in dropdown link to overview pages
- show event rows with image in genres/locations pages
- parse venue area data correctly on the server
- improve database query helper to release connections

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8554dde48330acb9d170953957f5