### PR TITLE
Implement visible user ID

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -97,6 +97,7 @@ app.post('/register-user', upload.fields([
             country,
             company,
             salutation,
+            visibleUserId,
         } = req.body;
 
         // 1) Pflichtfelder prüfen
@@ -184,11 +185,12 @@ app.post('/register-user', upload.fields([
                     disability_card_expiry_date,
                     is_currently_disabled,
                     role,
+                    visible_user_id,
                     created_at,
                     updated_at
                 ) VALUES (
                     $1, $2, $3, $4, $5, $6, $7, $8, $9,
-                    $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, NOW(), NOW()
+                    $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, NOW(), NOW()
                 ) RETURNING *;
             `,
             [
@@ -212,6 +214,7 @@ app.post('/register-user', upload.fields([
                 disabilityCardExpiryDate || '9999-01-01',
                 false,
                 userRoleId,
+                parseInt(visibleUserId, 10) || Math.floor(Math.random() * 90000000) + 10000000,
             ]
         );
 
@@ -266,6 +269,7 @@ app.post('/login-user', async (req, res) => {
                     password,
                     first_name,
                     last_name,
+                    visible_user_id,
                     request_for_disability,
                     is_currently_disabled,
                     disability_card_expiry_date,
@@ -292,6 +296,7 @@ app.post('/login-user', async (req, res) => {
         req.session.userId = user.user_id;
         req.session.email = user.email;
         req.session.role = user.role;
+        req.session.visibleUserId = user.visible_user_id;
 
         const { rows: markRows } = await client.query(
             'SELECT mark_code FROM user_disability_marks WHERE user_id = $1',
@@ -310,6 +315,7 @@ app.post('/login-user', async (req, res) => {
                 disabilityCardExpiryDate: user.disability_card_expiry_date,
                 disabilityMarks: markRows.map((m) => m.mark_code && m.mark_code.trim()),
                 role: user.role,
+                visibleUserId: user.visible_user_id,
             },
         });
     } catch (err) {
@@ -334,7 +340,8 @@ app.get('/session-status', async (req, res) => {
                     request_for_disability,
                     is_currently_disabled,
                     disability_card_expiry_date,
-                    role
+                    role,
+                    visible_user_id
        FROM users
        WHERE user_id = $1
        LIMIT 1`,
@@ -354,10 +361,14 @@ app.get('/session-status', async (req, res) => {
             is_currently_disabled,
             disability_card_expiry_date,
             role,
+            visible_user_id,
         } = rows[0];
 
         if (!req.session.role) {
             req.session.role = role;
+        }
+        if (!req.session.visibleUserId) {
+            req.session.visibleUserId = visible_user_id;
         }
 
         const { rows: markRows } = await client.query(
@@ -377,6 +388,7 @@ app.get('/session-status', async (req, res) => {
                 disabilityCardExpiryDate: disability_card_expiry_date,
                 disabilityMarks: markRows.map((m) => m.mark_code && m.mark_code.trim()),
                 role: req.session.role,
+                visibleUserId: req.session.visibleUserId,
             },
         });
     } catch (err) {

--- a/eventim-disability-integration/src/components/nav-bar.jsx
+++ b/eventim-disability-integration/src/components/nav-bar.jsx
@@ -397,6 +397,7 @@ export default function NavBar() {
                                         <p>Angemeldet als</p>
                                         <h3>
                                             {user.firstName} {user.lastName}
+                                            {user.visibleUserId ? ` (${user.visibleUserId})` : ''}
                                         </h3>
                                     </div>
                                 </div>

--- a/eventim-disability-integration/src/hooks/useAuth.js
+++ b/eventim-disability-integration/src/hooks/useAuth.js
@@ -28,6 +28,7 @@ export function useAuth() {
                         isCurrentlyDisabled: u.isCurrentlyDisabled,
                         disabilityCardExpiryDate: u.disabilityCardExpiryDate,
                         disabilityMarks: u.disabilityMarks || [],
+                        visibleUserId: u.visibleUserId,
                     },
                 });
             } catch {
@@ -56,6 +57,7 @@ export function useAuth() {
                             isCurrentlyDisabled: data.user.isCurrentlyDisabled,
                             disabilityCardExpiryDate: data.user.disabilityCardExpiryDate,
                             disabilityMarks: data.user.disabilityMarks || [],
+                            visibleUserId: data.user.visibleUserId,
                         },
                     });
                     localStorage.setItem(
@@ -69,6 +71,7 @@ export function useAuth() {
                             isCurrentlyDisabled: data.user.isCurrentlyDisabled,
                             disabilityCardExpiryDate: data.user.disabilityCardExpiryDate,
                             disabilityMarks: data.user.disabilityMarks || [],
+                            visibleUserId: data.user.visibleUserId,
                         })
                     );
                 } else {

--- a/eventim-disability-integration/src/pages/admin/login.jsx
+++ b/eventim-disability-integration/src/pages/admin/login.jsx
@@ -44,6 +44,7 @@ export default function LoginPage() {
                         email:     data.user.email,
                         firstName: data.user.firstName,
                         lastName:  data.user.lastName,
+                        visibleUserId: data.user.visibleUserId,
                     })
                 );
                 router.push('/').then(() => window.location.reload());

--- a/eventim-disability-integration/src/pages/login.jsx
+++ b/eventim-disability-integration/src/pages/login.jsx
@@ -59,6 +59,7 @@ export default function LoginPage() {
                         isCurrentlyDisabled: data.user.isCurrentlyDisabled,
                         disabilityCardExpiryDate: data.user.disabilityCardExpiryDate,
                         disabilityMarks: data.user.disabilityMarks,
+                        visibleUserId: data.user.visibleUserId,
                     })
                 );
                 router.push(redirect || '/').then(() => window.location.reload());

--- a/eventim-disability-integration/src/pages/registration.jsx
+++ b/eventim-disability-integration/src/pages/registration.jsx
@@ -158,6 +158,10 @@ export default function Registration() {
                 payload.append(key, formData[key]);
             });
 
+            // Generate an 8 digit visible user id
+            const visibleUserId = Math.floor(10000000 + Math.random() * 90000000);
+            payload.append('visibleUserId', visibleUserId);
+
             if (formData.disabilityCardImageFront) {
                 payload.append('disabilityCardImageFront', formData.disabilityCardImageFront);
             }

--- a/eventim-disability-integration/src/pages/service/login.jsx
+++ b/eventim-disability-integration/src/pages/service/login.jsx
@@ -44,6 +44,7 @@ export default function LoginPage() {
                         email:     data.user.email,
                         firstName: data.user.firstName,
                         lastName:  data.user.lastName,
+                        visibleUserId: data.user.visibleUserId,
                     })
                 );
                 router.push('/').then(() => window.location.reload());


### PR DESCRIPTION
## Summary
- generate an 8‑digit visible user id during registration
- persist and return the id from the server
- store the id in localStorage after login
- expose the id via `useAuth`
- show the id in the profile dropdown in `NavBar`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e61615e188330a7ce3c8705a24cbe