### PR TITLE
Add accepted request view and new disability modal

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -449,12 +449,31 @@ app.get('/pending-disability-requests', async (req, res) => {
     }
 });
 
+// Liefert akzeptierte Anträge der letzten 30 Tage
+app.get('/accepted-disability-requests', async (req, res) => {
+    try {
+        const { rows } = await client.query(
+            `SELECT user_id, visible_user_id, birth_date, updated_at
+               FROM users
+              WHERE is_currently_disabled = true
+                AND request_for_disability = true
+                AND updated_at >= NOW() - interval '30 days'
+              ORDER BY updated_at DESC`
+        );
+        return res.json({ requests: rows });
+    } catch (err) {
+        console.error('Error fetching accepted disability requests:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
 // Liefert die hinterlegten Disability-Daten eines Users
 app.get('/users/:id/disability', async (req, res) => {
     const userId = req.params.id;
     try {
         const { rows } = await client.query(
-            `SELECT disability_degree, disability_card_expiry_date,
+            `SELECT salutation, first_name, last_name,
+                    disability_degree, disability_card_expiry_date,
                     disability_card_image_front, disability_card_image_back
                FROM users
               WHERE user_id = $1
@@ -476,6 +495,11 @@ app.get('/users/:id/disability', async (req, res) => {
                 disability_card_image_front: user.disability_card_image_front,
                 disability_card_image_back: user.disability_card_image_back,
                 marks: markRows.map((m) => m.mark_code && m.mark_code.trim()),
+            },
+            user: {
+                salutation: user.salutation,
+                firstName: user.first_name,
+                lastName: user.last_name,
             },
         });
     } catch (err) {

--- a/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
+++ b/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function DisabilityRequestModal({ user, detail, imgFrontUrl, imgBackUrl, onClose }) {
+    if (!user || !detail) return null;
+
+    const formatDate = (d) =>
+        new Date(d).toLocaleDateString('de-DE', {
+            weekday: 'long',
+            day: '2-digit',
+            month: '2-digit',
+            year: 'numeric',
+        });
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="request-modal-grid" onClick={(e) => e.stopPropagation()}>
+                <h2>{user.visible_user_id}</h2>
+                <div className="request-modal-grid-left">
+                    <p><strong>Name:</strong> {user.salutation} {user.firstName} {user.lastName}</p>
+                    <p><strong>Grad der Behinderung:</strong> {detail.disability_degree}</p>
+                    <p><strong>Ausweis gültig bis:</strong> {detail.disability_card_expiry_date === '9998-12-31T23:00:00.000Z' ? 'unbegrenzt' : formatDate(detail.disability_card_expiry_date)}</p>
+                    <p><strong>Merkzeichen:</strong> {detail.marks && detail.marks.length ? detail.marks.join(', ') : 'Keine'}</p>
+                </div>
+                <div className="request-modal-grid-images">
+                    {imgFrontUrl && (
+                        <img src={imgFrontUrl} alt="Vorderseite" className="disability-card-image" />
+                    )}
+                    {imgBackUrl && (
+                        <img src={imgBackUrl} alt="Rückseite" className="disability-card-image" />
+                    )}
+                </div>
+                <div className="request-modal-actions">
+                    <button className="profile__btn-cancel">Annehmen</button>
+                    <button className="profile__btn-cancel" onClick={onClose}>Schließen</button>
+                    <button className="profile__btn-cancel">Ablehnen</button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+DisabilityRequestModal.propTypes = {
+    user: PropTypes.object,
+    detail: PropTypes.object,
+    imgFrontUrl: PropTypes.string,
+    imgBackUrl: PropTypes.string,
+    onClose: PropTypes.func,
+};

--- a/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
+++ b/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
@@ -3,16 +3,18 @@
 
 import React, { useEffect, useState } from 'react';
 import { API_BASE_URL } from '../../config';
+import DisabilityRequestModal from '../../components/DisabilityRequestModal';
 
 export default function CompensationRequests() {
     const [requests, setRequests] = useState([]);
+    const [acceptedRequests, setAcceptedRequests] = useState([]);
     const [selectedUser, setSelectedUser] = useState(null);
     const [detail, setDetail] = useState(null);
     const [imgFrontUrl, setImgFrontUrl] = useState(null);
     const [imgBackUrl, setImgBackUrl] = useState(null);
 
     useEffect(() => {
-        async function fetchRequests() {
+        async function fetchPending() {
             try {
                 const r = await fetch(`${API_BASE_URL}/pending-disability-requests`);
                 if (r.ok) {
@@ -23,7 +25,21 @@ export default function CompensationRequests() {
                 console.error('Error loading requests:', err);
             }
         }
-        fetchRequests();
+
+        async function fetchAccepted() {
+            try {
+                const r = await fetch(`${API_BASE_URL}/accepted-disability-requests`);
+                if (r.ok) {
+                    const js = await r.json();
+                    setAcceptedRequests(Array.isArray(js.requests) ? js.requests : []);
+                }
+            } catch (err) {
+                console.error('Error loading accepted requests:', err);
+            }
+        }
+
+        fetchPending();
+        fetchAccepted();
     }, []);
 
     const loadDetail = async (req) => {
@@ -32,7 +48,12 @@ export default function CompensationRequests() {
             if (!r.ok) return;
             const js = await r.json();
             setDetail(js.disabilityData || null);
-            setSelectedUser(req);
+            setSelectedUser({
+                ...req,
+                salutation: js.user?.salutation || '',
+                firstName: js.user?.firstName || '',
+                lastName: js.user?.lastName || '',
+            });
 
             if (js.disabilityData?.disability_card_image_front) {
                 const fr = await fetch(`${API_BASE_URL}/image/${js.disabilityData.disability_card_image_front}`);
@@ -99,30 +120,41 @@ export default function CompensationRequests() {
                 </tbody>
             </table>
 
+            <h1 className="admin-heading">Akzeptierte Anfragen (letzte 30 Tage)</h1>
+            <table className="profile-orders-table">
+                <thead>
+                    <tr>
+                        <th>User-ID</th>
+                        <th>Geburtsdatum</th>
+                        <th>Letzte Änderung</th>
+                        <th>Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {acceptedRequests.map((r) => (
+                        <tr key={r.user_id} className="clickable-row" onClick={() => loadDetail(r)}>
+                            <td>{r.visible_user_id}</td>
+                            <td>{formatDate(r.birth_date)}</td>
+                            <td>{formatDate(r.updated_at)}</td>
+                            <td>Akzeptiert</td>
+                        </tr>
+                    ))}
+                    {acceptedRequests.length === 0 && (
+                        <tr>
+                            <td colSpan="4">Keine akzeptierten Anträge</td>
+                        </tr>
+                    )}
+                </tbody>
+            </table>
+
             {selectedUser && detail && (
-                <div className="modal-overlay" onClick={closeModal}>
-                    <div className="modal-box" onClick={(e) => e.stopPropagation()}>
-                        <h2>User {selectedUser.visible_user_id}</h2>
-                        <div className="request-modal-content">
-                            <div className="request-modal-info">
-                                <p>Grad der Behinderung: {detail.disability_degree}</p>
-                                <p>Ausweis gültig bis: {detail.disability_card_expiry_date === '9998-12-31T23:00:00.000Z' ? 'unbegrenzt' : formatDate(detail.disability_card_expiry_date)}</p>
-                                <p>Merkzeichen: {detail.marks && detail.marks.length ? detail.marks.join(', ') : 'Keine'}</p>
-                            </div>
-                            <div className="request-modal-images">
-                                {imgFrontUrl && (
-                                    <img src={imgFrontUrl} alt="Vorderseite" className="disability-card-image" />
-                                )}
-                                {imgBackUrl && (
-                                    <img src={imgBackUrl} alt="Rückseite" className="disability-card-image" />
-                                )}
-                            </div>
-                        </div>
-                        <button className="profile__btn-cancel modal-close" onClick={closeModal}>
-                            Schließen
-                        </button>
-                    </div>
-                </div>
+                <DisabilityRequestModal
+                    user={selectedUser}
+                    detail={detail}
+                    imgFrontUrl={imgFrontUrl}
+                    imgBackUrl={imgBackUrl}
+                    onClose={closeModal}
+                />
             )}
         </div>
     );

--- a/eventim-disability-integration/src/styles/service.css
+++ b/eventim-disability-integration/src/styles/service.css
@@ -51,3 +51,41 @@
 .modal-close {
     margin-top: 1rem;
 }
+
+.request-modal-grid {
+    background-color: white;
+    padding: 1rem;
+    border-radius: 10px;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto 1fr auto;
+    gap: 1rem;
+}
+
+.request-modal-grid h2 {
+    grid-column: span 2;
+    margin: 0;
+    text-align: left;
+}
+
+.request-modal-grid-left {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+}
+
+.request-modal-grid-images {
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.request-modal-actions {
+    grid-column: span 2;
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add new modal component for disability requests
- fetch and display accepted requests
- show user name and disability details in grid layout
- add new API routes for accepted requests and expanded user info
- style modal with CSS grid

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e84d0a89c833084807a12d3c8f833