### PR TITLE
Implement disability request approval actions

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -508,6 +508,42 @@ app.get('/users/:id/disability', async (req, res) => {
     }
 });
 
+// Accept a disability request
+app.post('/disability-requests/:id/accept', async (req, res) => {
+    const userId = req.params.id;
+    try {
+        await client.query(
+            `UPDATE users
+                SET is_currently_disabled = true,
+                    updated_at = NOW()
+              WHERE user_id = $1`,
+            [userId]
+        );
+        return res.json({ message: 'Request accepted' });
+    } catch (err) {
+        console.error('Error accepting disability request:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
+// Decline a disability request
+app.post('/disability-requests/:id/decline', async (req, res) => {
+    const userId = req.params.id;
+    try {
+        await client.query(
+            `UPDATE users
+                SET request_for_disability = false,
+                    updated_at = NOW()
+              WHERE user_id = $1`,
+            [userId]
+        );
+        return res.json({ message: 'Request declined' });
+    } catch (err) {
+        console.error('Error declining disability request:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
 // Temporäres Speichern der Versandinformationen in der Session (wird später in der DB gespeichert)
 app.post('/checkout-shipping', (req, res) => {
     if (!req.session.userId) {

--- a/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
+++ b/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
@@ -1,7 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function DisabilityRequestModal({ user, detail, imgFrontUrl, imgBackUrl, onClose }) {
+export default function DisabilityRequestModal({
+    user,
+    detail,
+    imgFrontUrl,
+    imgBackUrl,
+    onClose,
+    onAccept,
+    onDecline,
+}) {
     if (!user || !detail) return null;
 
     const formatDate = (d) =>
@@ -32,9 +40,21 @@ export default function DisabilityRequestModal({ user, detail, imgFrontUrl, imgB
                     )}
                 </div>
                 <div className="request-modal-actions">
-                    <button className="profile__btn-cancel" style={{backgroundColor: "green"}}>✓ </button>
+                    <button
+                        className="profile__btn-cancel"
+                        style={{ backgroundColor: 'green' }}
+                        onClick={onAccept}
+                    >
+                        ✓
+                    </button>
                     <button className="profile__btn-cancel" onClick={onClose}>Schließen</button>
-                    <button className="profile__btn-cancel" style={{backgroundColor: "red"}}> x </button>
+                    <button
+                        className="profile__btn-cancel"
+                        style={{ backgroundColor: 'red' }}
+                        onClick={onDecline}
+                    >
+                        x
+                    </button>
                 </div>
             </div>
         </div>
@@ -47,4 +67,6 @@ DisabilityRequestModal.propTypes = {
     imgFrontUrl: PropTypes.string,
     imgBackUrl: PropTypes.string,
     onClose: PropTypes.func,
+    onAccept: PropTypes.func,
+    onDecline: PropTypes.func,
 };

--- a/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
+++ b/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
@@ -13,31 +13,31 @@ export default function CompensationRequests() {
     const [imgFrontUrl, setImgFrontUrl] = useState(null);
     const [imgBackUrl, setImgBackUrl] = useState(null);
 
+    const fetchPending = async () => {
+        try {
+            const r = await fetch(`${API_BASE_URL}/pending-disability-requests`);
+            if (r.ok) {
+                const js = await r.json();
+                setRequests(Array.isArray(js.requests) ? js.requests : []);
+            }
+        } catch (err) {
+            console.error('Error loading requests:', err);
+        }
+    };
+
+    const fetchAccepted = async () => {
+        try {
+            const r = await fetch(`${API_BASE_URL}/accepted-disability-requests`);
+            if (r.ok) {
+                const js = await r.json();
+                setAcceptedRequests(Array.isArray(js.requests) ? js.requests : []);
+            }
+        } catch (err) {
+            console.error('Error loading accepted requests:', err);
+        }
+    };
+
     useEffect(() => {
-        async function fetchPending() {
-            try {
-                const r = await fetch(`${API_BASE_URL}/pending-disability-requests`);
-                if (r.ok) {
-                    const js = await r.json();
-                    setRequests(Array.isArray(js.requests) ? js.requests : []);
-                }
-            } catch (err) {
-                console.error('Error loading requests:', err);
-            }
-        }
-
-        async function fetchAccepted() {
-            try {
-                const r = await fetch(`${API_BASE_URL}/accepted-disability-requests`);
-                if (r.ok) {
-                    const js = await r.json();
-                    setAcceptedRequests(Array.isArray(js.requests) ? js.requests : []);
-                }
-            } catch (err) {
-                console.error('Error loading accepted requests:', err);
-            }
-        }
-
         fetchPending();
         fetchAccepted();
     }, []);
@@ -81,6 +81,28 @@ export default function CompensationRequests() {
         setImgBackUrl(null);
         setSelectedUser(null);
         setDetail(null);
+    };
+
+    const acceptRequest = async () => {
+        if (!selectedUser) return;
+        try {
+            await fetch(`${API_BASE_URL}/disability-requests/${selectedUser.user_id}/accept`, { method: 'POST' });
+        } catch (err) {
+            console.error('Error accepting request:', err);
+        }
+        closeModal();
+        await Promise.all([fetchPending(), fetchAccepted()]);
+    };
+
+    const declineRequest = async () => {
+        if (!selectedUser) return;
+        try {
+            await fetch(`${API_BASE_URL}/disability-requests/${selectedUser.user_id}/decline`, { method: 'POST' });
+        } catch (err) {
+            console.error('Error declining request:', err);
+        }
+        closeModal();
+        await Promise.all([fetchPending(), fetchAccepted()]);
     };
 
     const formatDate = (d) =>
@@ -179,6 +201,8 @@ export default function CompensationRequests() {
                         imgFrontUrl={imgFrontUrl}
                         imgBackUrl={imgBackUrl}
                         onClose={closeModal}
+                        onAccept={acceptRequest}
+                        onDecline={declineRequest}
                     />
                 )}
             </div>


### PR DESCRIPTION
## Summary
- add accept/decline endpoints on the Express server
- wire accept/decline actions into DisabilityRequestModal
- refresh lists after approving/declining a request

## Testing
- `npx jest --runInBand` *(fails: Test Suites 2 failed)*

------
https://chatgpt.com/codex/tasks/task_e_685e97dac4388330b96664a585c83e1d