### PR TITLE
Implement ticket table for admin user detail

### DIFF
--- a/eventim-disability-integration/src/components/UserDetailModal.jsx
+++ b/eventim-disability-integration/src/components/UserDetailModal.jsx
@@ -5,6 +5,9 @@ import { API_BASE_URL } from '../config';
 export default function UserDetailModal({ user, orders, onClose }) {
     if (!user) return null;
 
+    const [expandedOrder, setExpandedOrder] = React.useState(null);
+    const [tickets, setTickets] = React.useState([]);
+
     const formatDate = (d) => new Date(d).toLocaleDateString('de-DE', {
         weekday: 'long',
         day: '2-digit',
@@ -14,6 +17,24 @@ export default function UserDetailModal({ user, orders, onClose }) {
     const formatTime = (d) => new Date(d).toLocaleTimeString('de-DE', { hour: '2-digit', minute: '2-digit' });
 
     const isSent = (oDate) => new Date(oDate).getTime() < Date.now() - 3 * 24 * 60 * 60 * 1000;
+
+    const toggleOrder = async (orderId) => {
+        if (expandedOrder === orderId) {
+            setExpandedOrder(null);
+            setTickets([]);
+            return;
+        }
+        try {
+            const res = await fetch(`${API_BASE_URL}/orders/${orderId}`);
+            if (res.ok) {
+                const data = await res.json();
+                setExpandedOrder(orderId);
+                setTickets(Array.isArray(data.tickets) ? data.tickets : []);
+            }
+        } catch (err) {
+            console.error('Error fetching order detail:', err);
+        }
+    };
 
     return (
         <div className="service__modal-overlay" onClick={onClose}>
@@ -46,12 +67,45 @@ export default function UserDetailModal({ user, orders, onClose }) {
                         </thead>
                         <tbody>
                         {orders.map((o, idx) => (
-                            <tr key={o.id}>
-                                <td>#{orders.length - idx}</td>
-                                <td>{formatDate(o.created_at)} | {formatTime(o.created_at)}</td>
-                                <td>{o.ticket_count}</td>
-                                <td><span className={`order-status ${isSent(o.created_at) ? 'send' : 'progress'}`}>{isSent(o.created_at) ? 'In Zustellung' : 'In Bearbeitung'}</span></td>
-                            </tr>
+                            <React.Fragment key={o.id}>
+                                <tr className="order-row" onClick={() => toggleOrder(o.id)}>
+                                    <td>#{orders.length - idx}</td>
+                                    <td>{formatDate(o.created_at)} | {formatTime(o.created_at)}</td>
+                                    <td>{o.ticket_count}</td>
+                                    <td><span className={`order-status ${isSent(o.created_at) ? 'send' : 'progress'}`}>{isSent(o.created_at) ? 'In Zustellung' : 'In Bearbeitung'}</span></td>
+                                </tr>
+                                {expandedOrder === o.id && (
+                                    <tr>
+                                        <td colSpan="4">
+                                            <table className="tickets-table" style={{ marginLeft: '2rem' }}>
+                                                <thead>
+                                                    <tr>
+                                                        <th>Event</th>
+                                                        <th>Kategorie</th>
+                                                        <th>Sitz</th>
+                                                        <th>Preis</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                    {tickets.map(t => (
+                                                        <tr key={t.id}>
+                                                            <td>{t.event_title}</td>
+                                                            <td>{t.event_category}</td>
+                                                            <td>{t.seat_number}</td>
+                                                            <td>{t.price}</td>
+                                                        </tr>
+                                                    ))}
+                                                    {tickets.length === 0 && (
+                                                        <tr>
+                                                            <td colSpan="4">Keine Tickets</td>
+                                                        </tr>
+                                                    )}
+                                                </tbody>
+                                            </table>
+                                        </td>
+                                    </tr>
+                                )}
+                            </React.Fragment>
                         ))}
                         {orders.length === 0 && (
                             <tr>


### PR DESCRIPTION
## Summary
- show user orders in a modal with expandable ticket view
- fetch ticket info when clicking an order row

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff5fdd90083309a8714a8e1657a10