### PR TITLE
Enable admin role assignment

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -303,6 +303,16 @@ app.post('/login-user', async (req, res) => {
             [user.user_id]
         );
 
+        const { rows: roleRows } = await client.query(
+            'SELECT has_role_appointing_capability FROM user_roles WHERE id = $1',
+            [user.role]
+        );
+
+        const canAppoint =
+            roleRows.length && roleRows[0].has_role_appointing_capability;
+
+        req.session.hasRoleAppointingCapability = !!canAppoint;
+
         return res.status(200).json({
             message: 'Login erfolgreich',
             user: {
@@ -316,6 +326,7 @@ app.post('/login-user', async (req, res) => {
                 disabilityMarks: markRows.map((m) => m.mark_code && m.mark_code.trim()),
                 role: user.role,
                 visibleUserId: user.visible_user_id,
+                hasRoleAppointingCapability: !!canAppoint,
             },
         });
     } catch (err) {
@@ -376,6 +387,18 @@ app.get('/session-status', async (req, res) => {
             [req.session.userId]
         );
 
+        const { rows: roleRows } = await client.query(
+            'SELECT has_role_appointing_capability FROM user_roles WHERE id = $1',
+            [req.session.role]
+        );
+
+        const canAppoint =
+            roleRows.length && roleRows[0].has_role_appointing_capability;
+
+        if (req.session.hasRoleAppointingCapability === undefined) {
+            req.session.hasRoleAppointingCapability = !!canAppoint;
+        }
+
         return res.status(200).json({
             loggedIn: true,
             user: {
@@ -389,6 +412,7 @@ app.get('/session-status', async (req, res) => {
                 disabilityMarks: markRows.map((m) => m.mark_code && m.mark_code.trim()),
                 role: req.session.role,
                 visibleUserId: req.session.visibleUserId,
+                hasRoleAppointingCapability: !!canAppoint,
             },
         });
     } catch (err) {
@@ -749,6 +773,53 @@ app.get('/users/:id/orders', async (req, res) => {
         return res.json({ orders: rows });
     } catch (err) {
         console.error('Error fetching user orders:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
+// Rolle eines Nutzers aktualisieren
+app.put('/users/:id/role', async (req, res) => {
+    if (!req.session.userId) {
+        return res.status(401).json({ message: 'Not logged in' });
+    }
+
+    const userId = req.params.id;
+    const { roleId } = req.body;
+
+    if (!roleId) {
+        return res.status(400).json({ message: 'roleId required' });
+    }
+
+    try {
+        const { rows: permRows } = await client.query(
+            'SELECT has_role_appointing_capability FROM user_roles WHERE id = $1',
+            [req.session.role]
+        );
+
+        if (!permRows.length || !permRows[0].has_role_appointing_capability) {
+            return res.status(403).json({ message: 'Forbidden' });
+        }
+
+        await client.query(
+            'UPDATE users SET role = $1, updated_at = NOW() WHERE user_id = $2',
+            [roleId, userId]
+        );
+
+        const { rows } = await client.query(
+            `SELECT u.user_id,
+                    u.visible_user_id,
+                    u.created_at,
+                    u.role,
+                    ur.name AS role_name
+               FROM users u
+                    JOIN user_roles ur ON ur.id = u.role
+              WHERE u.user_id = $1`,
+            [userId]
+        );
+
+        return res.json({ user: rows[0] });
+    } catch (err) {
+        console.error('Error updating user role:', err);
         return res.status(500).json({ message: 'Server error' });
     }
 });

--- a/eventim-disability-integration/src/components/UserDetailModal.jsx
+++ b/eventim-disability-integration/src/components/UserDetailModal.jsx
@@ -2,11 +2,13 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { API_BASE_URL } from '../config';
 
-export default function UserDetailModal({ user, orders, onClose }) {
+export default function UserDetailModal({ user, orders, onClose, roles = [], canEditRole = false, onRoleUpdated }) {
     if (!user) return null;
 
     const [expandedOrderId, setExpandedOrderId] = useState(null);
     const [tickets, setTickets] = useState([]);
+    const [editMode, setEditMode] = useState(false);
+    const [selectedRole, setSelectedRole] = useState(user.role);
 
     const formatDate = (d) => new Date(d).toLocaleDateString('de-DE', {
         weekday: 'long',
@@ -33,6 +35,24 @@ export default function UserDetailModal({ user, orders, onClose }) {
             }
         } catch (err) {
             console.error('Error fetching order detail:', err);
+        }
+    };
+
+    const handleSaveRole = async () => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/users/${user.user_id}/role`, {
+                method: 'PUT',
+                credentials: 'include',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ roleId: selectedRole }),
+            });
+            if (res.ok) {
+                const data = await res.json();
+                onRoleUpdated && onRoleUpdated(data.user, user.role);
+                setEditMode(false);
+            }
+        } catch (err) {
+            console.error('Error updating role:', err);
         }
     };
 
@@ -123,6 +143,20 @@ export default function UserDetailModal({ user, orders, onClose }) {
                     </table>
                 </div>
                 <div className="request-modal-actions">
+                    {canEditRole && (
+                        !editMode ? (
+                            <button className="profile__btn-cancel" onClick={() => setEditMode(true)}>Rolle anpassen</button>
+                        ) : (
+                            <>
+                                <select className="role-select" value={selectedRole} onChange={e => setSelectedRole(e.target.value)}>
+                                    {roles.map(r => (
+                                        <option key={r.id} value={r.id}>{r.name}</option>
+                                    ))}
+                                </select>
+                                <button className="profile__btn-cancel" onClick={handleSaveRole}>Speichern</button>
+                            </>
+                        )
+                    )}
                     <button className="profile__btn-cancel" style={{backgroundColor: '#ccc'}} onClick={onClose}>Schließen</button>
                 </div>
             </div>
@@ -134,4 +168,7 @@ UserDetailModal.propTypes = {
     user: PropTypes.object,
     orders: PropTypes.array,
     onClose: PropTypes.func,
+    roles: PropTypes.array,
+    canEditRole: PropTypes.bool,
+    onRoleUpdated: PropTypes.func,
 };

--- a/eventim-disability-integration/src/hooks/useAuth.js
+++ b/eventim-disability-integration/src/hooks/useAuth.js
@@ -29,6 +29,7 @@ export function useAuth() {
                         disabilityCardExpiryDate: u.disabilityCardExpiryDate,
                         disabilityMarks: u.disabilityMarks || [],
                         visibleUserId: u.visibleUserId,
+                        hasRoleAppointingCapability: u.hasRoleAppointingCapability,
                     },
                 });
             } catch {
@@ -58,6 +59,7 @@ export function useAuth() {
                             disabilityCardExpiryDate: data.user.disabilityCardExpiryDate,
                             disabilityMarks: data.user.disabilityMarks || [],
                             visibleUserId: data.user.visibleUserId,
+                            hasRoleAppointingCapability: data.user.hasRoleAppointingCapability,
                         },
                     });
                     localStorage.setItem(
@@ -72,6 +74,7 @@ export function useAuth() {
                             disabilityCardExpiryDate: data.user.disabilityCardExpiryDate,
                             disabilityMarks: data.user.disabilityMarks || [],
                             visibleUserId: data.user.visibleUserId,
+                            hasRoleAppointingCapability: data.user.hasRoleAppointingCapability,
                         })
                     );
                 } else {

--- a/eventim-disability-integration/src/pages/login.jsx
+++ b/eventim-disability-integration/src/pages/login.jsx
@@ -60,6 +60,8 @@ export default function LoginPage() {
                         disabilityCardExpiryDate: data.user.disabilityCardExpiryDate,
                         disabilityMarks: data.user.disabilityMarks,
                         visibleUserId: data.user.visibleUserId,
+                        role: data.user.role,
+                        hasRoleAppointingCapability: data.user.hasRoleAppointingCapability,
                     })
                 );
                 router.push(redirect || '/').then(() => window.location.reload());

--- a/eventim-disability-integration/src/pages/service/account-management.jsx
+++ b/eventim-disability-integration/src/pages/service/account-management.jsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import UserDetailModal from '../../components/UserDetailModal';
 import { API_BASE_URL } from '../../config';
+import { useAuth } from '../../hooks/useAuth';
 
 export default function UserOverview() {
     const [roles, setRoles] = useState([]);
     const [usersByRole, setUsersByRole] = useState({});
     const [selectedUser, setSelectedUser] = useState(null);
     const [selectedOrders, setSelectedOrders] = useState([]);
+    const { user } = useAuth();
 
     useEffect(() => {
         fetchRoles();
@@ -57,6 +59,19 @@ export default function UserOverview() {
         } catch (err) {
             console.error('Error loading user detail:', err);
         }
+    };
+
+    const handleRoleUpdated = (updatedUser, previousRole) => {
+        setUsersByRole(prev => {
+            const newState = { ...prev };
+            if (newState[previousRole]) {
+                newState[previousRole] = newState[previousRole].filter(u => u.user_id !== updatedUser.user_id);
+            }
+            if (!newState[updatedUser.role]) newState[updatedUser.role] = [];
+            newState[updatedUser.role] = [updatedUser, ...newState[updatedUser.role]];
+            return newState;
+        });
+        setSelectedUser(updatedUser);
     };
 
     const closeModal = () => {
@@ -116,7 +131,14 @@ export default function UserOverview() {
                 </div>
             ))}
             {selectedUser && (
-                <UserDetailModal user={selectedUser} orders={selectedOrders} onClose={closeModal} />
+                <UserDetailModal
+                    user={selectedUser}
+                    orders={selectedOrders}
+                    onClose={closeModal}
+                    roles={roles}
+                    canEditRole={user?.hasRoleAppointingCapability}
+                    onRoleUpdated={handleRoleUpdated}
+                />
             )}
         </div>
     );

--- a/eventim-disability-integration/src/styles/service.css
+++ b/eventim-disability-integration/src/styles/service.css
@@ -158,3 +158,21 @@
     justify-content: center;
     z-index: 10;
 }
+
+.role-select {
+    padding: 0.5rem 0.75rem;
+    font-size: 1rem;
+    line-height: 1;
+    color: #333;
+    font-family: inherit;
+    border: 1px solid #cccccc;
+    border-radius: 4px;
+    background-color: #ffffff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.role-select:focus {
+    outline: none;
+    border-color: #007bff;
+    box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.25);
+}


### PR DESCRIPTION
## Summary
- expose hasRoleAppointingCapability on login and session APIs
- add API endpoint to change a user's role
- show role management button in account overview when allowed
- support editing roles inside the user detail modal
- style new role select element

## Testing
- `npm test --silent` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68612392b9fc8330afc4f0d15a9b913a