### PR TITLE
Implement role-based access control

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -304,14 +304,24 @@ app.post('/login-user', async (req, res) => {
         );
 
         const { rows: roleRows } = await client.query(
-            'SELECT has_role_appointing_capability FROM user_roles WHERE id = $1',
+            `SELECT has_role_appointing_capability,
+                    has_disability_approval_access,
+                    has_account_management_access,
+                    has_creation_access,
+                    has_editing_access,
+                    has_deletion_permission
+               FROM user_roles WHERE id = $1`,
             [user.role]
         );
 
-        const canAppoint =
-            roleRows.length && roleRows[0].has_role_appointing_capability;
-
-        req.session.hasRoleAppointingCapability = !!canAppoint;
+        const perms = roleRows[0] || {};
+        const canAppoint = !!perms.has_role_appointing_capability;
+        req.session.hasRoleAppointingCapability = canAppoint;
+        req.session.hasDisabilityApprovalAccess = !!perms.has_disability_approval_access;
+        req.session.hasAccountManagementAccess = !!perms.has_account_management_access;
+        req.session.hasCreationAccess = !!perms.has_creation_access;
+        req.session.hasEditingAccess = !!perms.has_editing_access;
+        req.session.hasDeletionPermission = !!perms.has_deletion_permission;
 
         return res.status(200).json({
             message: 'Login erfolgreich',
@@ -326,7 +336,12 @@ app.post('/login-user', async (req, res) => {
                 disabilityMarks: markRows.map((m) => m.mark_code && m.mark_code.trim()),
                 role: user.role,
                 visibleUserId: user.visible_user_id,
-                hasRoleAppointingCapability: !!canAppoint,
+                hasRoleAppointingCapability: canAppoint,
+                hasDisabilityApprovalAccess: !!perms.has_disability_approval_access,
+                hasAccountManagementAccess: !!perms.has_account_management_access,
+                hasCreationAccess: !!perms.has_creation_access,
+                hasEditingAccess: !!perms.has_editing_access,
+                hasDeletionPermission: !!perms.has_deletion_permission,
             },
         });
     } catch (err) {
@@ -388,15 +403,34 @@ app.get('/session-status', async (req, res) => {
         );
 
         const { rows: roleRows } = await client.query(
-            'SELECT has_role_appointing_capability FROM user_roles WHERE id = $1',
+            `SELECT has_role_appointing_capability,
+                    has_disability_approval_access,
+                    has_account_management_access,
+                    has_creation_access,
+                    has_editing_access,
+                    has_deletion_permission
+               FROM user_roles WHERE id = $1`,
             [req.session.role]
         );
-
-        const canAppoint =
-            roleRows.length && roleRows[0].has_role_appointing_capability;
-
+        const perms = roleRows[0] || {};
+        const canAppoint = !!perms.has_role_appointing_capability;
         if (req.session.hasRoleAppointingCapability === undefined) {
-            req.session.hasRoleAppointingCapability = !!canAppoint;
+            req.session.hasRoleAppointingCapability = canAppoint;
+        }
+        if (req.session.hasDisabilityApprovalAccess === undefined) {
+            req.session.hasDisabilityApprovalAccess = !!perms.has_disability_approval_access;
+        }
+        if (req.session.hasAccountManagementAccess === undefined) {
+            req.session.hasAccountManagementAccess = !!perms.has_account_management_access;
+        }
+        if (req.session.hasCreationAccess === undefined) {
+            req.session.hasCreationAccess = !!perms.has_creation_access;
+        }
+        if (req.session.hasEditingAccess === undefined) {
+            req.session.hasEditingAccess = !!perms.has_editing_access;
+        }
+        if (req.session.hasDeletionPermission === undefined) {
+            req.session.hasDeletionPermission = !!perms.has_deletion_permission;
         }
 
         return res.status(200).json({
@@ -412,7 +446,12 @@ app.get('/session-status', async (req, res) => {
                 disabilityMarks: markRows.map((m) => m.mark_code && m.mark_code.trim()),
                 role: req.session.role,
                 visibleUserId: req.session.visibleUserId,
-                hasRoleAppointingCapability: !!canAppoint,
+                hasRoleAppointingCapability: canAppoint,
+                hasDisabilityApprovalAccess: req.session.hasDisabilityApprovalAccess,
+                hasAccountManagementAccess: req.session.hasAccountManagementAccess,
+                hasCreationAccess: req.session.hasCreationAccess,
+                hasEditingAccess: req.session.hasEditingAccess,
+                hasDeletionPermission: req.session.hasDeletionPermission,
             },
         });
     } catch (err) {

--- a/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
+++ b/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
@@ -40,21 +40,25 @@ export default function DisabilityRequestModal({
                     )}
                 </div>
                 <div className="request-modal-actions">
-                    <button
-                        className="profile__btn-cancel"
-                        style={{ backgroundColor: 'green' }}
-                        onClick={onAccept}
-                    >
-                        ✓
-                    </button>
-                    <button className="profile__btn-cancel" onClick={onClose} style={{backgroundColor: "grey"}}>Schließen</button>
-                    <button
-                        className="profile__btn-cancel"
-                        style={{ backgroundColor: 'red' }}
-                        onClick={onDecline}
-                    >
-                        x
-                    </button>
+                    {onAccept && (
+                        <button
+                            className="profile__btn-cancel"
+                            style={{ backgroundColor: 'green' }}
+                            onClick={onAccept}
+                        >
+                            ✓
+                        </button>
+                    )}
+                    <button className="profile__btn-cancel" onClick={onClose} style={{backgroundColor: 'grey'}}>Schließen</button>
+                    {onDecline && (
+                        <button
+                            className="profile__btn-cancel"
+                            style={{ backgroundColor: 'red' }}
+                            onClick={onDecline}
+                        >
+                            x
+                        </button>
+                    )}
                 </div>
             </div>
         </div>

--- a/eventim-disability-integration/src/components/UserDetailModal.jsx
+++ b/eventim-disability-integration/src/components/UserDetailModal.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { API_BASE_URL } from '../config';
 
-export default function UserDetailModal({ user, orders, onClose, roles = [], canEditRole = false, onRoleUpdated }) {
+export default function UserDetailModal({ user, orders, onClose, roles = [], canEditRole = false, currentUserId, onRoleUpdated }) {
     if (!user) return null;
 
     const [expandedOrderId, setExpandedOrderId] = useState(null);
@@ -143,7 +143,7 @@ export default function UserDetailModal({ user, orders, onClose, roles = [], can
                     </table>
                 </div>
                 <div className="request-modal-actions">
-                    {canEditRole && (
+                    {canEditRole && user.user_id !== currentUserId && (
                         !editMode ? (
                             <button className="profile__btn-cancel" onClick={() => setEditMode(true)}>Rolle anpassen</button>
                         ) : (
@@ -170,5 +170,6 @@ UserDetailModal.propTypes = {
     onClose: PropTypes.func,
     roles: PropTypes.array,
     canEditRole: PropTypes.bool,
+    currentUserId: PropTypes.string,
     onRoleUpdated: PropTypes.func,
 };

--- a/eventim-disability-integration/src/components/nav-bar.jsx
+++ b/eventim-disability-integration/src/components/nav-bar.jsx
@@ -383,12 +383,16 @@ export default function NavBar() {
                                 <a href="/profile" className="dropdown-item">
                                     EVENTIM - Profil
                                 </a>
-                                <a href="/service" className="dropdown-item">
-                                    EVENTIM - Service Center
-                                </a>
-                                <a href="/admin" className="dropdown-item">
-                                    EVENTIM - Admin Tooling
-                                </a>
+                                {user.hasDisabilityApprovalAccess && (
+                                    <a href="/service" className="dropdown-item">
+                                        EVENTIM - Service Center
+                                    </a>
+                                )}
+                                {(user.hasCreationAccess || user.hasEditingAccess || user.hasDeletionPermission) && (
+                                    <a href="/admin" className="dropdown-item">
+                                        EVENTIM - Admin Tooling
+                                    </a>
+                                )}
 
                                 <div className="dropdown-divider" />
 

--- a/eventim-disability-integration/src/hooks/useAuth.js
+++ b/eventim-disability-integration/src/hooks/useAuth.js
@@ -29,7 +29,13 @@ export function useAuth() {
                         disabilityCardExpiryDate: u.disabilityCardExpiryDate,
                         disabilityMarks: u.disabilityMarks || [],
                         visibleUserId: u.visibleUserId,
+                        role: u.role,
                         hasRoleAppointingCapability: u.hasRoleAppointingCapability,
+                        hasDisabilityApprovalAccess: u.hasDisabilityApprovalAccess,
+                        hasAccountManagementAccess: u.hasAccountManagementAccess,
+                        hasCreationAccess: u.hasCreationAccess,
+                        hasEditingAccess: u.hasEditingAccess,
+                        hasDeletionPermission: u.hasDeletionPermission,
                     },
                 });
             } catch {
@@ -60,6 +66,16 @@ export function useAuth() {
                             disabilityMarks: data.user.disabilityMarks || [],
                             visibleUserId: data.user.visibleUserId,
                             hasRoleAppointingCapability: data.user.hasRoleAppointingCapability,
+                            hasDisabilityApprovalAccess: data.user.hasDisabilityApprovalAccess,
+                            hasAccountManagementAccess: data.user.hasAccountManagementAccess,
+                            hasCreationAccess: data.user.hasCreationAccess,
+                            hasEditingAccess: data.user.hasEditingAccess,
+                            hasDeletionPermission: data.user.hasDeletionPermission,
+                            hasDisabilityApprovalAccess: data.user.hasDisabilityApprovalAccess,
+                            hasAccountManagementAccess: data.user.hasAccountManagementAccess,
+                            hasCreationAccess: data.user.hasCreationAccess,
+                            hasEditingAccess: data.user.hasEditingAccess,
+                            hasDeletionPermission: data.user.hasDeletionPermission,
                         },
                     });
                     localStorage.setItem(
@@ -74,7 +90,13 @@ export function useAuth() {
                             disabilityCardExpiryDate: data.user.disabilityCardExpiryDate,
                             disabilityMarks: data.user.disabilityMarks || [],
                             visibleUserId: data.user.visibleUserId,
+                            role: data.user.role,
                             hasRoleAppointingCapability: data.user.hasRoleAppointingCapability,
+                            hasDisabilityApprovalAccess: data.user.hasDisabilityApprovalAccess,
+                            hasAccountManagementAccess: data.user.hasAccountManagementAccess,
+                            hasCreationAccess: data.user.hasCreationAccess,
+                            hasEditingAccess: data.user.hasEditingAccess,
+                            hasDeletionPermission: data.user.hasDeletionPermission,
                         })
                     );
                 } else {

--- a/eventim-disability-integration/src/hooks/useRequireAccess.js
+++ b/eventim-disability-integration/src/hooks/useRequireAccess.js
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { useAuth } from './useAuth';
+
+export function useRequireAccess(required = []) {
+    const { loading, loggedIn, user } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+        if (loading) return;
+        const allowed = required.every((f) => user && user[f]);
+        if (!loggedIn) {
+            router.replace(`/login?redirect=${encodeURIComponent(router.asPath)}`);
+        } else if (!allowed) {
+            router.replace('/');
+        }
+    }, [loading, loggedIn, user, router, required]);
+
+    return { loading, loggedIn, user };
+}

--- a/eventim-disability-integration/src/pages/admin/artists/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/artists/create.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { useRequireAccess } from '../../../hooks/useRequireAccess';
 
 export default function ArtistCreation() {
+    useRequireAccess(['hasCreationAccess']);
     const router = useRouter();
     const [formData, setFormData] = useState({
         name: '',

--- a/eventim-disability-integration/src/pages/admin/artists/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/artists/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import FilterBar from '../../../components/filter-bar';
 import { useRouter } from 'next/router';
+import { useAuth } from '../../../hooks/useAuth';
 
 export default function ArtistsContent() {
     const [artists, setArtists] = useState([]);
@@ -18,6 +19,7 @@ export default function ArtistsContent() {
     const [expandedIds, setExpandedIds] = useState(new Set());
 
     const router = useRouter();
+    const { user } = useAuth();
 
     const filterFields = [
         { key: 'name', label: 'Name', match: 'startsWith' },
@@ -128,12 +130,14 @@ export default function ArtistsContent() {
         <div className="artists-wrapper">
             <div className="artists-header">
                 <h2 className="artists-title">Übersicht – Künstler</h2>
-                <button
-                    className="btn-create-entity"
-                    onClick={() => router.push(`/admin/artists/create`)}
-                >
-                    + Künstler erstellen
-                </button>
+                {user?.hasCreationAccess && (
+                    <button
+                        className="btn-create-entity"
+                        onClick={() => router.push(`/admin/artists/create`)}
+                    >
+                        + Künstler erstellen
+                    </button>
+                )}
             </div>
 
             <div className="filter-container">
@@ -174,13 +178,15 @@ export default function ArtistsContent() {
                                     💾
                                 </button>
                             ) : (
-                                <button
-                                    className="btn-edit"
-                                    onClick={() => handleEditToggle(artist)}
-                                    title="Bearbeiten"
-                                >
-                                    ✎
-                                </button>
+                                user?.hasEditingAccess && (
+                                    <button
+                                        className="btn-edit"
+                                        onClick={() => handleEditToggle(artist)}
+                                        title="Bearbeiten"
+                                    >
+                                        ✎
+                                    </button>
+                                )
                             )}
                         </div>
 

--- a/eventim-disability-integration/src/pages/admin/countries/cities/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/cities/create.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { useRequireAccess } from '../../../../hooks/useRequireAccess';
 
 export default function CityCreation() {
+    useRequireAccess(['hasCreationAccess']);
     const router = useRouter();
     const [formData, setFormData] = useState({
         name: '',

--- a/eventim-disability-integration/src/pages/admin/countries/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/create.jsx
@@ -1,8 +1,10 @@
 // country.jsx (in your Next.js pages or components folder)
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
+import { useRequireAccess } from '../../../hooks/useRequireAccess';
 
 export default function CountryCreation() {
+    useRequireAccess(['hasCreationAccess']);
     const router = useRouter();
     const [formData, setFormData] = useState({ name: '', code: '' });
     const [message, setMessage] = useState('');

--- a/eventim-disability-integration/src/pages/admin/genres/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/genres/create.jsx
@@ -1,8 +1,10 @@
 // genres.jsx
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
+import { useRequireAccess } from '../../../hooks/useRequireAccess';
 
 export default function GenreCreation() {
+    useRequireAccess(['hasCreationAccess']);
     const router = useRouter();
     const [formData, setFormData] = useState({
         name: '',

--- a/eventim-disability-integration/src/pages/admin/tours/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/create.jsx
@@ -2,8 +2,10 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { useRequireAccess } from '../../../hooks/useRequireAccess';
 
 export default function TourCreation() {
+    useRequireAccess(['hasCreationAccess']);
     // --------------------------------------------------
     // 1) State
     // --------------------------------------------------

--- a/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
@@ -2,8 +2,10 @@
 
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { useRequireAccess } from '../../../../hooks/useRequireAccess';
 
 export default function EventCreation() {
+    useRequireAccess(['hasCreationAccess']);
     const router = useRouter();
     const [formData, setFormData] = useState({
         tourId: '',

--- a/eventim-disability-integration/src/pages/admin/tours/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/index.jsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import FilterBar from '../../../components/filter-bar';
 import { useRouter } from 'next/router';
 import { API_BASE_URL } from '../../../config';
+import { useAuth } from '../../../hooks/useAuth';
 
 export default function ToursContent() {
     const [tours, setTours] = useState([]);
@@ -34,6 +35,7 @@ export default function ToursContent() {
     const [filterArtists, setFilterArtists] = useState([]);
 
     const router = useRouter();
+    const { user } = useAuth();
 
     const filterFields = [
         { key: 'title', label: 'Titel', match: 'startsWith' },
@@ -262,12 +264,14 @@ export default function ToursContent() {
             {/* Header + Create */}
             <div className="artists-header">
                 <h2 className="artists-title">Übersicht – Touren</h2>
-                <button
-                    className="btn-create-entity"
-                    onClick={() => router.push(`/admin/tours/create`)}
-                >
-                    + Tour erstellen
-                </button>
+                {user?.hasCreationAccess && (
+                    <button
+                        className="btn-create-entity"
+                        onClick={() => router.push(`/admin/tours/create`)}
+                    >
+                        + Tour erstellen
+                    </button>
+                )}
             </div>
 
             {/* Filter */}
@@ -656,25 +660,29 @@ export default function ToursContent() {
                             {/* Edit + Delete icons */}
                             {editingId !== tour.id && (
                                 <div className="card-footer-icons">
-                                    <button
-                                        className="btn-edit small-edit"
-                                        onClick={() => handleEditToggle(tour)}
-                                        title="Bearbeiten"
-                                    >
-                                        ✎
-                                    </button>
-                                    <button
-                                        className="btn-edit delete-icon"
-                                        onClick={() => setConfirmDeleteId(tour.id)}
-                                        title="Löschen"
-                                    >
-                                        🗑
-                                    </button>
+                                    {user?.hasEditingAccess && (
+                                        <button
+                                            className="btn-edit small-edit"
+                                            onClick={() => handleEditToggle(tour)}
+                                            title="Bearbeiten"
+                                        >
+                                            ✎
+                                        </button>
+                                    )}
+                                    {user?.hasDeletionPermission && (
+                                        <button
+                                            className="btn-edit delete-icon"
+                                            onClick={() => setConfirmDeleteId(tour.id)}
+                                            title="Löschen"
+                                        >
+                                            🗑
+                                        </button>
+                                    )}
                                 </div>
                             )}
 
                             {/* Delete modal */}
-                            {confirmDeleteId === tour.id && (
+                            {confirmDeleteId === tour.id && user?.hasDeletionPermission && (
                                 <div className="modal-overlay">
                                     <div className="modal-box">
                                         <p>Möchtest du diese Tour wirklich löschen?</p>

--- a/eventim-disability-integration/src/pages/admin/venues/areas/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/areas/create.jsx
@@ -1,8 +1,10 @@
 "use client";
 
 import React, { useState } from 'react';
+import { useRequireAccess } from '../../../../hooks/useRequireAccess';
 
 export default function AreaCreation() {
+    useRequireAccess(['hasCreationAccess']);
     const [formData, setFormData] = useState({
         name: '',
         description: ''

--- a/eventim-disability-integration/src/pages/admin/venues/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/create.jsx
@@ -1,8 +1,10 @@
 // venues.jsx (Next.js Komponente mit disability area capacities)
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/router';
+import { useRequireAccess } from '../../../hooks/useRequireAccess';
 
 export default function VenueCreation() {
+    useRequireAccess(['hasCreationAccess']);
     const router = useRouter();
     const [formData, setFormData] = useState({
         name: '',

--- a/eventim-disability-integration/src/pages/admin/venues/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/index.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import FilterBar from '../../../components/filter-bar';
 import { useRouter } from 'next/router';
+import { useAuth } from '../../../hooks/useAuth';
 
 export default function VenuesContent() {
     const [venues, setVenues] = useState([]);
@@ -19,6 +20,7 @@ export default function VenuesContent() {
     const [confirmDeleteId, setConfirmDeleteId] = useState(null);
 
     const router = useRouter();
+    const { user } = useAuth();
 
     const filterFields = [
         { key: 'name', label: 'Name', match: 'startsWith' },
@@ -145,12 +147,14 @@ export default function VenuesContent() {
         <div className="artists-wrapper">
             <div className="artists-header">
                 <h2 className="artists-title">Übersicht – Venues</h2>
-                <button
-                    className="btn-create-entity"
-                    onClick={() => router.push('/admin/venues/create')}
-                >
-                    + Venue erstellen
-                </button>
+                {user?.hasCreationAccess && (
+                    <button
+                        className="btn-create-entity"
+                        onClick={() => router.push('/admin/venues/create')}
+                    >
+                        + Venue erstellen
+                    </button>
+                )}
             </div>
 
             <div className="filter-container">
@@ -208,13 +212,15 @@ export default function VenuesContent() {
                                     💾
                                 </button>
                             ) : (
-                                <button
-                                    className="btn-edit"
-                                    onClick={() => handleEditToggle(venue)}
-                                    title="Bearbeiten"
-                                >
-                                    ✎
-                                </button>
+                                user?.hasEditingAccess && (
+                                    <button
+                                        className="btn-edit"
+                                        onClick={() => handleEditToggle(venue)}
+                                        title="Bearbeiten"
+                                    >
+                                        ✎
+                                    </button>
+                                )
                             )}
                         </div>
 
@@ -340,7 +346,7 @@ export default function VenuesContent() {
                             </div>
                         </div>
 
-                        {editingId !== venue.id && (
+                        {editingId !== venue.id && user?.hasDeletionPermission && (
                             <button
                                 className="btn-edit"
                                 style={{ marginLeft: 'auto', marginRight: '0.5rem' }}
@@ -351,7 +357,7 @@ export default function VenuesContent() {
                             </button>
                         )}
 
-                        {confirmDeleteId === venue.id && (
+                        {confirmDeleteId === venue.id && user?.hasDeletionPermission && (
                             <div className="modal-overlay">
                                 <div className="modal-box">
                                     <p>Möchtest du dieses Venue wirklich löschen?</p>

--- a/eventim-disability-integration/src/pages/login.jsx
+++ b/eventim-disability-integration/src/pages/login.jsx
@@ -62,6 +62,11 @@ export default function LoginPage() {
                         visibleUserId: data.user.visibleUserId,
                         role: data.user.role,
                         hasRoleAppointingCapability: data.user.hasRoleAppointingCapability,
+                        hasDisabilityApprovalAccess: data.user.hasDisabilityApprovalAccess,
+                        hasAccountManagementAccess: data.user.hasAccountManagementAccess,
+                        hasCreationAccess: data.user.hasCreationAccess,
+                        hasEditingAccess: data.user.hasEditingAccess,
+                        hasDeletionPermission: data.user.hasDeletionPermission,
                     })
                 );
                 router.push(redirect || '/').then(() => window.location.reload());

--- a/eventim-disability-integration/src/pages/service/account-management.jsx
+++ b/eventim-disability-integration/src/pages/service/account-management.jsx
@@ -2,8 +2,10 @@ import React, { useEffect, useState } from 'react';
 import UserDetailModal from '../../components/UserDetailModal';
 import { API_BASE_URL } from '../../config';
 import { useAuth } from '../../hooks/useAuth';
+import { useRequireAccess } from '../../hooks/useRequireAccess';
 
 export default function UserOverview() {
+    useRequireAccess(['hasDisabilityApprovalAccess', 'hasAccountManagementAccess']);
     const [roles, setRoles] = useState([]);
     const [usersByRole, setUsersByRole] = useState({});
     const [selectedUser, setSelectedUser] = useState(null);
@@ -137,6 +139,7 @@ export default function UserOverview() {
                     onClose={closeModal}
                     roles={roles}
                     canEditRole={user?.hasRoleAppointingCapability}
+                    currentUserId={user?.userId}
                     onRoleUpdated={handleRoleUpdated}
                 />
             )}

--- a/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
+++ b/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
@@ -4,8 +4,12 @@
 import React, { useEffect, useState } from 'react';
 import { API_BASE_URL } from '../../config';
 import DisabilityRequestModal from '../../components/DisabilityRequestModal';
+import { useRequireAccess } from '../../hooks/useRequireAccess';
+import { useAuth } from '../../hooks/useAuth';
 
 export default function CompensationRequests() {
+    useRequireAccess(['hasDisabilityApprovalAccess']);
+    const { user } = useAuth();
     const [requests, setRequests] = useState([]);
     const [acceptedRequests, setAcceptedRequests] = useState([]);
     const [selectedUser, setSelectedUser] = useState(null);
@@ -201,8 +205,8 @@ export default function CompensationRequests() {
                         imgFrontUrl={imgFrontUrl}
                         imgBackUrl={imgBackUrl}
                         onClose={closeModal}
-                        onAccept={acceptRequest}
-                        onDecline={declineRequest}
+                        onAccept={user?.hasDisabilityApprovalAccess ? acceptRequest : undefined}
+                        onDecline={user?.hasDisabilityApprovalAccess ? declineRequest : undefined}
                     />
                 )}
             </div>

--- a/eventim-disability-integration/src/pages/service/index.jsx
+++ b/eventim-disability-integration/src/pages/service/index.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { useRequireAccess } from '../../hooks/useRequireAccess';
 
 export default function AdminTooling() {
+    useRequireAccess(['hasDisabilityApprovalAccess']);
     const links = [
         { label: 'Disability Functions', url: 'service/disabilityFunction' },
         { label: 'Bookings', url: 'service/bookings' },


### PR DESCRIPTION
## Summary
- add permission check hook
- store and propagate role permissions on login
- restrict service pages and admin create pages using the hook
- hide editing and deletion tools without permission
- show/hide service/admin links in nav bar
- expose permissions through the API

## Testing
- `npm test --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6861343942bc8330a84b665751dfa81c