### PR TITLE
Add search bar to account management

### DIFF
--- a/eventim-disability-integration/src/pages/service/account-management.jsx
+++ b/eventim-disability-integration/src/pages/service/account-management.jsx
@@ -10,6 +10,8 @@ export default function UserOverview() {
     const [usersByRole, setUsersByRole] = useState({});
     const [selectedUser, setSelectedUser] = useState(null);
     const [selectedOrders, setSelectedOrders] = useState([]);
+    const [searchId, setSearchId] = useState('');
+    const [searchBirthDate, setSearchBirthDate] = useState('');
     const { user } = useAuth();
 
     useEffect(() => {
@@ -90,6 +92,21 @@ export default function UserOverview() {
 
     return (
         <div className="profile-container" style={{ flexDirection: 'column' }}>
+            <div className="user-search-bar">
+                <input
+                    type="text"
+                    className="user-search-input"
+                    placeholder="User-ID suchen…"
+                    value={searchId}
+                    onChange={(e) => setSearchId(e.target.value)}
+                />
+                <input
+                    type="date"
+                    className="user-search-input"
+                    value={searchBirthDate}
+                    onChange={(e) => setSearchBirthDate(e.target.value)}
+                />
+            </div>
             {roles.map(role => (
                 <div key={role.id} className="content-inner" style={{ paddingTop: '24px' }}>
                     <div className="white-box events-white-box">
@@ -111,7 +128,13 @@ export default function UserOverview() {
                                     </tr>
                                     </thead>
                                     <tbody>
-                                    {(usersByRole[role.id] || []).map(u => (
+                                    {(usersByRole[role.id] || [])
+                                        .filter(u => {
+                                            const idOk = !searchId || String(u.visible_user_id).includes(searchId);
+                                            const birthOk = !searchBirthDate || (u.birth_date && u.birth_date.startsWith(searchBirthDate));
+                                            return idOk && birthOk;
+                                        })
+                                        .map(u => (
                                         <tr key={u.user_id} className="clickable-row" onClick={() => openUser(u.user_id)}>
                                             <td>{u.visible_user_id}</td>
                                             <td>{formatDate(u.created_at)}</td>

--- a/eventim-disability-integration/src/styles/service.css
+++ b/eventim-disability-integration/src/styles/service.css
@@ -176,3 +176,20 @@
     border-color: #007bff;
     box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.25);
 }
+
+/* Search bar for account management */
+.user-search-bar {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.user-search-input {
+    flex: 1;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background-color: #fff;
+    font-size: 0.95rem;
+    color: #333;
+}


### PR DESCRIPTION
## Summary
- implement ID and birth date search on account management page
- style search bar in `service.css`

## Testing
- `npm test --silent` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68613c5963d883308dc918da8e47aeef