### PR TITLE
Add DB constraints and error handling

### DIFF
--- a/eventim-disability-integration/server/backup.sql
+++ b/eventim-disability-integration/server/backup.sql
@@ -1,0 +1,263 @@
+-- Basic schema backup to recreate database tables
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Countries and Cities
+CREATE TABLE IF NOT EXISTS countries (
+    id uuid PRIMARY KEY,
+    name varchar(100) NOT NULL,
+    iso_code char(2)
+);
+
+CREATE TABLE IF NOT EXISTS cities (
+    id uuid PRIMARY KEY,
+    name varchar(100) NOT NULL,
+    country_id uuid REFERENCES countries(id)
+);
+
+-- Users and roles
+CREATE TABLE IF NOT EXISTS user_roles (
+    id uuid PRIMARY KEY,
+    name varchar(50) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS users (
+    user_id uuid PRIMARY KEY,
+    first_name varchar(100) NOT NULL,
+    last_name varchar(100) NOT NULL,
+    email varchar(255) NOT NULL,
+    password text NOT NULL,
+    birth_date date,
+    phone varchar(20),
+    request_for_disability boolean,
+    disability_degree integer,
+    street_address varchar(255),
+    city varchar(100),
+    postal_code varchar(20),
+    country varchar(100),
+    company varchar(255),
+    salutation varchar(20),
+    disability_card_image_front uuid,
+    disability_card_image_back uuid,
+    disability_card_expiry_date date,
+    is_currently_disabled boolean,
+    role uuid REFERENCES user_roles(id),
+    visible_user_id integer,
+    created_at timestamptz,
+    updated_at timestamptz
+);
+
+-- Artists and Genres
+CREATE TABLE IF NOT EXISTS artists (
+    id uuid PRIMARY KEY,
+    name varchar(255) NOT NULL,
+    biography text,
+    website varchar(255),
+    created_at timestamptz,
+    updated_at timestamptz,
+    artist_image uuid
+);
+
+CREATE TABLE IF NOT EXISTS genres (
+    id uuid PRIMARY KEY,
+    name varchar(50) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS subgenres (
+    id uuid PRIMARY KEY,
+    genre_id uuid REFERENCES genres(id),
+    name text
+);
+
+CREATE TABLE IF NOT EXISTS artist_genres (
+    artist_id uuid REFERENCES artists(id),
+    genre_id uuid REFERENCES genres(id)
+);
+
+-- Tours and related tables
+CREATE TABLE IF NOT EXISTS tours (
+    id uuid PRIMARY KEY,
+    title varchar(255) NOT NULL,
+    subtitle varchar(255),
+    start_date date,
+    end_date date,
+    created_at timestamptz,
+    updated_at timestamptz,
+    tour_image uuid
+);
+
+CREATE TABLE IF NOT EXISTS tour_artists (
+    tour_id uuid REFERENCES tours(id),
+    artist_id uuid REFERENCES artists(id)
+);
+
+CREATE TABLE IF NOT EXISTS tour_genres (
+    tour_id uuid REFERENCES tours(id),
+    genre_id uuid REFERENCES genres(id)
+);
+
+CREATE TABLE IF NOT EXISTS tour_subgenres (
+    tour_id uuid REFERENCES tours(id),
+    subgenre_id uuid REFERENCES subgenres(id)
+);
+
+-- Venues and areas
+CREATE TABLE IF NOT EXISTS venues (
+    id uuid PRIMARY KEY,
+    name varchar(255) NOT NULL,
+    address varchar(500),
+    city_id uuid REFERENCES cities(id),
+    website varchar(255),
+    created_at timestamptz,
+    updated_at timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS areas (
+    id uuid PRIMARY KEY,
+    name varchar(50),
+    description varchar(100),
+    disability_category_for char(3)
+);
+
+CREATE TABLE IF NOT EXISTS venue_areas (
+    id uuid PRIMARY KEY,
+    venue_id uuid REFERENCES venues(id),
+    max_capacity integer,
+    area_id uuid REFERENCES areas(id)
+);
+
+CREATE TABLE IF NOT EXISTS event_venue_areas (
+    id uuid PRIMARY KEY,
+    event_id uuid REFERENCES events(id),
+    venue_area_id uuid REFERENCES venue_areas(id),
+    capacity integer,
+    category_id uuid
+);
+
+-- Events and categories
+CREATE TABLE IF NOT EXISTS events (
+    id uuid PRIMARY KEY,
+    tour_id uuid REFERENCES tours(id),
+    venue_id uuid REFERENCES venues(id),
+    description text,
+    created_at timestamptz,
+    updated_at timestamptz,
+    start_time timestamptz,
+    end_time timestamptz,
+    door_time timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS event_categories (
+    id uuid PRIMARY KEY,
+    event_id uuid REFERENCES events(id),
+    name text,
+    price numeric(10,2),
+    disability_support_for char(3)
+);
+
+CREATE TABLE IF NOT EXISTS event_supporting_acts (
+    event_id uuid REFERENCES events(id),
+    artist_id uuid REFERENCES artists(id)
+);
+
+-- Commerce tables
+CREATE TABLE IF NOT EXISTS carts (
+    id uuid PRIMARY KEY,
+    user_id uuid REFERENCES users(user_id),
+    created_at timestamptz,
+    updated_at timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS cart_items (
+    id uuid PRIMARY KEY,
+    cart_id uuid REFERENCES carts(id),
+    event_id uuid REFERENCES events(id),
+    event_category_id uuid REFERENCES event_categories(id),
+    quantity integer,
+    added_at timestamptz,
+    is_assistance_ticket boolean
+);
+
+CREATE TABLE IF NOT EXISTS checkouts (
+    id uuid PRIMARY KEY,
+    user_id uuid REFERENCES users(user_id),
+    created_at timestamptz,
+    updated_at timestamptz
+);
+
+CREATE TABLE IF NOT EXISTS checkout_items (
+    id uuid PRIMARY KEY,
+    checkout_id uuid REFERENCES checkouts(id),
+    event_category_id uuid REFERENCES event_categories(id),
+    event_id uuid REFERENCES events(id),
+    quantity integer,
+    price numeric(10,2),
+    added_at timestamptz,
+    is_assistance_ticket boolean
+);
+
+CREATE TABLE IF NOT EXISTS orders (
+    id uuid PRIMARY KEY,
+    checkout_id uuid REFERENCES checkouts(id),
+    user_id uuid REFERENCES users(user_id),
+    created_at timestamptz,
+    street_address varchar(255),
+    postal_code varchar(20),
+    city varchar(100),
+    country varchar(100),
+    is_paid boolean,
+    salutation varchar(20),
+    first_name varchar(100),
+    last_name varchar(100),
+    company varchar(255),
+    payment_option_id uuid
+);
+
+CREATE TABLE IF NOT EXISTS tickets (
+    id uuid PRIMARY KEY,
+    order_id uuid REFERENCES orders(id),
+    event_category_id uuid REFERENCES event_categories(id),
+    seat_number varchar(50),
+    price numeric(10,2),
+    created_at timestamptz,
+    is_assistance_ticket boolean
+);
+
+CREATE TABLE IF NOT EXISTS payment_options (
+    id uuid PRIMARY KEY,
+    label varchar(50),
+    description varchar(100),
+    icon_src varchar(50)
+);
+
+CREATE TABLE IF NOT EXISTS shipping_options (
+    id uuid PRIMARY KEY,
+    label varchar(100),
+    price numeric,
+    description varchar(100)
+);
+
+CREATE TABLE IF NOT EXISTS disability_marks (
+    mark_code char(3) PRIMARY KEY,
+    description varchar(100),
+    area_id uuid REFERENCES areas(id)
+);
+
+CREATE TABLE IF NOT EXISTS user_disability_marks (
+    user_id uuid REFERENCES users(user_id),
+    mark_code char(3) REFERENCES disability_marks(mark_code)
+);
+
+CREATE TABLE IF NOT EXISTS images (
+    id uuid PRIMARY KEY,
+    image_data bytea,
+    image_type text,
+    entity_type text,
+    entity_id uuid
+);
+
+CREATE TABLE IF NOT EXISTS order_tickets (
+    id uuid PRIMARY KEY,
+    order_id uuid REFERENCES orders(id),
+    ticket_id uuid REFERENCES tickets(id)
+);

--- a/eventim-disability-integration/server/database_ensurement.sql
+++ b/eventim-disability-integration/server/database_ensurement.sql
@@ -1,0 +1,85 @@
+-- Ensure database integrity by adding unique constraints and triggers
+
+-- Prevent duplicate user emails
+ALTER TABLE users
+    ADD CONSTRAINT unique_user_email UNIQUE (email);
+
+-- Prevent duplicate city names within a country
+ALTER TABLE cities
+    ADD CONSTRAINT unique_city_name_per_country UNIQUE (country_id, name);
+
+-- Ensure artists have unique names
+ALTER TABLE artists
+    ADD CONSTRAINT unique_artist_name UNIQUE (name);
+
+-- Unique title and dates for tours
+ALTER TABLE tours
+    ADD CONSTRAINT unique_tour_title_dates UNIQUE (title, start_date, end_date);
+
+-- Unique start time per venue
+ALTER TABLE events
+    ADD CONSTRAINT unique_event_start_per_venue UNIQUE (venue_id, start_time);
+
+-- Unique genre names
+ALTER TABLE genres
+    ADD CONSTRAINT unique_genre_name UNIQUE (name);
+
+-- Unique payment option labels
+ALTER TABLE payment_options
+    ADD CONSTRAINT unique_payment_option_label UNIQUE (label);
+
+-- Restrict deletion of last user per role
+CREATE OR REPLACE FUNCTION prevent_last_user_role_delete()
+RETURNS trigger AS $$
+BEGIN
+    IF (SELECT COUNT(*) FROM users WHERE role = OLD.role AND user_id <> OLD.user_id) = 0 THEN
+        RAISE EXCEPTION 'Cannot delete the last user with this role';
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_prevent_last_user_role_delete ON users;
+CREATE TRIGGER trg_prevent_last_user_role_delete
+BEFORE DELETE ON users
+FOR EACH ROW
+EXECUTE PROCEDURE prevent_last_user_role_delete();
+
+-- Restrict tour deletion when tickets exist
+CREATE OR REPLACE FUNCTION prevent_tour_delete_when_tickets()
+RETURNS trigger AS $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM events e
+        JOIN event_categories ec ON ec.event_id = e.id
+        JOIN tickets t ON t.event_category_id = ec.id
+        WHERE e.tour_id = OLD.id
+    ) THEN
+        RAISE EXCEPTION 'Cannot delete tour with existing tickets';
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_prevent_tour_delete ON tours;
+CREATE TRIGGER trg_prevent_tour_delete
+BEFORE DELETE ON tours
+FOR EACH ROW
+EXECUTE PROCEDURE prevent_tour_delete_when_tickets();
+
+-- Restrict event_category deletion when tickets exist
+CREATE OR REPLACE FUNCTION prevent_event_category_delete()
+RETURNS trigger AS $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM tickets WHERE event_category_id = OLD.id) THEN
+        RAISE EXCEPTION 'Cannot delete event category with existing tickets';
+    END IF;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_prevent_event_category_delete ON event_categories;
+CREATE TRIGGER trg_prevent_event_category_delete
+BEFORE DELETE ON event_categories
+FOR EACH ROW
+EXECUTE PROCEDURE prevent_event_category_delete();

--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -247,6 +247,9 @@ app.post('/register-user', upload.fields([
         });
     } catch (error) {
         console.error('Registration error:', error);
+        if (error.code === '23505' && error.constraint === 'unique_user_email') {
+            return res.status(409).json({ message: 'E-Mail ist bereits registriert.' });
+        }
         return res.status(500).json({ message: 'Serverfehler während der Registrierung' });
     }
 });
@@ -900,6 +903,9 @@ app.post('/create-artist', upload.single('artistImage'), async (req, res) => {
         res.status(201).json({ message: 'Artist created', artist });
     } catch (error) {
         console.error('Create-artist error:', error);
+        if (error.code === '23505' && error.constraint === 'unique_artist_name') {
+            return res.status(409).json({ message: 'Künstler mit diesem Namen existiert bereits.' });
+        }
         res.status(500).json({ message: 'Server error during artist creation' });
     }
 });
@@ -1136,6 +1142,9 @@ app.post('/create-tour', upload.single('tourImage'), async (req, res) => {
     } catch (error) {
         await client.query('ROLLBACK');
         console.error('Create-tour error:', error);
+        if (error.code === '23505' && error.constraint === 'unique_tour_title_dates') {
+            return res.status(409).json({ message: 'Eine Tour mit diesen Daten existiert bereits.' });
+        }
         return res.status(500).json({ message: 'Serverfehler beim Erstellen der Tour' });
     }
 });
@@ -1158,6 +1167,9 @@ app.post('/create-city', express.json(), async (req, res) => {
         res.status(201).json({ message: 'Stadt erstellt', city: result.rows[0] });
     } catch (error) {
         console.error('Create-city error:', error);
+        if (error.code === '23505' && error.constraint === 'unique_city_name_per_country') {
+            return res.status(409).json({ message: 'Stadt existiert bereits in diesem Land.' });
+        }
         res.status(500).json({ message: 'Serverfehler beim Erstellen der Stadt' });
     }
 });
@@ -1504,6 +1516,9 @@ app.post('/create-event', express.json(), async (req, res) => {
     } catch (err) {
         await client.query('ROLLBACK');
         console.error('Create-event error:', err);
+        if (err.code === '23505' && err.constraint === 'unique_event_start_per_venue') {
+            return res.status(409).json({ message: 'In diesem Zeitraum besteht bereits ein Event an diesem Veranstaltungsort.' });
+        }
         return res.status(500).json({ message: 'Serverfehler beim Erstellen des Events' });
     }
 });
@@ -1556,6 +1571,9 @@ app.post('/create-genre', async (req, res) => {
     } catch (err) {
         await client.query('ROLLBACK');
         console.error('Create-genre error:', err);
+        if (err.code === '23505' && err.constraint === 'unique_genre_name') {
+            return res.status(409).json({ message: 'Genre existiert bereits.' });
+        }
         res.status(500).json({ message: 'Serverfehler beim Erstellen des Genres' });
     }
 });
@@ -2252,6 +2270,9 @@ app.delete('/tours/:id', async (req, res) => {
         return res.status(200).json({ message: 'Tour gelöscht' });
     } catch (err) {
         console.error('Delete‐Tour error:', err);
+        if (err.code === 'P0001') {
+            return res.status(400).json({ message: err.message });
+        }
         return res.status(500).json({ message: 'Serverfehler beim Löschen der Tour' });
     }
 });


### PR DESCRIPTION
## Summary
- add database_ensurement.sql with unique constraints and triggers
- add backup.sql to recreate schema
- handle constraint violations in server for user, city, artist, tour, genre and event creation
- expose trigger errors on tour delete

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686147a610148330b903adf340deb641