### PR TITLE
Add overview pages for admin and service

### DIFF
--- a/eventim-disability-integration/src/pages/admin/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/index.jsx
@@ -1,57 +1,33 @@
 import React from 'react';
 
-export default function AdminTooling() {
-    const links = [
-        { label: 'Artist', url: 'admin/artists' },
-        { label: 'Countries', url: 'admin/countries' },
-        { label: 'Cities', url: 'admin/cities' },
-        { label: 'Genres', url: 'admin/genres' },
-        { label: 'Tours', url: 'admin/tours' },
-        { label: 'Events', url: 'admin/tours/events' },
-        { label: 'Venues', url: 'admin/venues' },
-        { label: 'Areas', url: 'admin/areas/venues' },
-        { label: 'User-Accounts', url: 'admin/userAccounts' },
-        { label: 'Service-Accounts', url: 'admin/serviceAccounts' },
-        { label: 'Admin-Accounts', url: 'admin/adminAccounts' },
+export default function AdminHome() {
+    const entities = [
+        { name: 'Artists', url: '/admin/artists' },
+        { name: 'Countries', url: '/admin/countries' },
+        { name: 'Cities', url: '/admin/cities' },
+        { name: 'Genres', url: '/admin/genres' },
+        { name: 'Tours', url: '/admin/tours' },
+        { name: 'Events', url: '/admin/tours/events' },
+        { name: 'Venues', url: '/admin/venues' },
+        { name: 'Areas', url: '/admin/venues/areas' }
     ];
 
-    const firstLinks = links.slice(0, 8);
-    const secondLinks = links.slice(8);
-
     return (
-        <div className="admin-container">
-            <h1 className="admin-heading">Admin-Tooling</h1>
-
-            <div className="button-row">
-                {firstLinks.map((link, index) => (
-                    <a
-                        key={index}
-                        href={link.url}
-                        className="admin-button"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        {link.label}
-                    </a>
-                ))}
-            </div>
-
-            <div className="horizontal-separator"></div>
-
-            <h1 className="admin-heading">Accounts-Tooling</h1>
-
-            <div className="button-row">
-                {secondLinks.map((link, index) => (
-                    <a
-                        key={index}
-                        href={link.url}
-                        className="admin-button"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        {link.label}
-                    </a>
-                ))}
+        <div className="profile-container" style={{ flexDirection: 'column' }}>
+            <div className="content-inner" style={{ paddingTop: '24px' }}>
+                <div className="white-box events-white-box">
+                    <div className="content-inner">
+                        <h1 className="events-header">Admin Übersicht</h1>
+                        <div className="profile-section-divider" />
+                        <div className="tile-grid">
+                            {entities.map(e => (
+                                <a key={e.url} href={e.url} className="tile-link">
+                                    {e.name} verwalten
+                                </a>
+                            ))}
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/eventim-disability-integration/src/pages/service/index.jsx
+++ b/eventim-disability-integration/src/pages/service/index.jsx
@@ -1,52 +1,30 @@
 import React from 'react';
 import { useRequireAccess } from '../../hooks/useRequireAccess';
 
-export default function AdminTooling() {
+export default function ServiceHome() {
     useRequireAccess(['hasDisabilityApprovalAccess']);
+
     const links = [
-        { label: 'Disability Functions', url: 'service/disabilityFunction' },
-        { label: 'Bookings', url: 'service/bookings' },
-        { label: 'User-Accounts', url: 'service/userAccounts' },
-        { label: 'Service-Accounts', url: 'service/serviceAccounts' },
+        { label: 'Ausgleichsanträge', url: '/service/compensation-for-disadvantages-requests' },
+        { label: 'Account-Management', url: '/service/account-management' }
     ];
 
-    const firstLinks = links.slice(0, 2);
-    const secondLinks = links.slice(2);
-
     return (
-        <div className="admin-container">
-            <h1 className="admin-heading">Service-Tooling</h1>
-
-            <div className="button-row">
-                {firstLinks.map((link, index) => (
-                    <a
-                        key={index}
-                        href={link.url}
-                        className="admin-button"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        {link.label}
-                    </a>
-                ))}
-            </div>
-
-            <div className="horizontal-separator"></div>
-
-            <h1 className="admin-heading">Accounts-Tooling</h1>
-
-            <div className="button-row">
-                {secondLinks.map((link, index) => (
-                    <a
-                        key={index}
-                        href={link.url}
-                        className="admin-button"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        {link.label}
-                    </a>
-                ))}
+        <div className="profile-container" style={{ flexDirection: 'column' }}>
+            <div className="content-inner" style={{ paddingTop: '24px' }}>
+                <div className="white-box events-white-box">
+                    <div className="content-inner">
+                        <h1 className="events-header">Service Übersicht</h1>
+                        <div className="profile-section-divider" />
+                        <div className="tile-grid">
+                            {links.map(link => (
+                                <a key={link.url} href={link.url} className="tile-link">
+                                    {link.label}
+                                </a>
+                            ))}
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/eventim-disability-integration/src/styles/service.css
+++ b/eventim-disability-integration/src/styles/service.css
@@ -198,3 +198,32 @@
     font-size: 0.95rem;
     color: #333;
 }
+
+/* Overview tile grid */
+.tile-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: flex-start;
+}
+
+.tile-link {
+    width: 180px;
+    height: 180px;
+    background-color: #ffffff;
+    border: 2px solid #e0e0e0;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+    color: #002b55;
+    font-weight: bold;
+    text-align: center;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tile-link:hover {
+    transform: scale(1.1);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}


### PR DESCRIPTION
## Summary
- redesign admin and service landing pages
- add Fiori-style tile grid
- add CSS styles for tiles

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686247403bf083309509125969bd974e