### PR TITLE
Add frontend validation and email check

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -737,6 +737,18 @@ app.get('/countries', async (req, res) => {
     }
 });
 
+app.get('/email-exists', async (req, res) => {
+    const email = req.query.email;
+    if (!email) return res.status(400).json({ message: 'Email erforderlich' });
+    try {
+        const { rows } = await client.query('SELECT 1 FROM users WHERE email = $1 LIMIT 1', [email.trim()]);
+        return res.json({ exists: rows.length > 0 });
+    } catch (err) {
+        console.error('Error checking email:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
 // ---------- Admin: User Management ----------
 // Liefert alle Rollen
 app.get('/user-roles', async (req, res) => {

--- a/eventim-disability-integration/src/hooks/useValidation.js
+++ b/eventim-disability-integration/src/hooks/useValidation.js
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+
+export function useValidation(initialErrors = {}) {
+  const [errors, setErrors] = useState(initialErrors);
+
+  const validate = (field, value, options = {}) => {
+    let error = '';
+    if (options.required && (!value || !value.trim())) {
+      error = 'Dieses Feld ist erforderlich';
+    }
+    if (!error && options.pattern && value) {
+      if (!options.pattern.test(value)) {
+        error = options.message || 'Ungültiges Format';
+      }
+    }
+    setErrors(prev => ({ ...prev, [field]: error }));
+    return !error;
+  };
+
+  const classFor = (field, value) => {
+    if (value === undefined || value === null || value === '') return '';
+    return errors[field] ? 'input-invalid' : 'input-valid';
+  };
+
+  const isValid = () => Object.values(errors).every(e => !e);
+
+  return { errors, validate, classFor, isValid };
+}

--- a/eventim-disability-integration/src/pages/admin/artists/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/artists/create.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useValidation } from '../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 
@@ -14,6 +15,7 @@ export default function ArtistCreation() {
     const [countries, setCountries] = useState([]);
     const [message, setMessage] = useState('');
     const [loading, setLoading] = useState(false);
+    const validation = useValidation({ name: '', website: '' });
 
     useEffect(() => {
         // Länder-Daten für Dropdown laden
@@ -29,6 +31,19 @@ export default function ArtistCreation() {
             setFormData(prev => ({ ...prev, artistImage: files[0] }));
         } else {
             setFormData(prev => ({ ...prev, [name]: value }));
+            if (name === 'name') {
+                validation.validate('name', value, { required: true });
+            }
+            if (name === 'website') {
+                if (value) {
+                    validation.validate('website', value, {
+                        pattern: /^https?:\/\//i,
+                        message: 'Ungültige URL',
+                    });
+                } else {
+                    validation.validate('website', value);
+                }
+            }
         }
     };
 
@@ -37,8 +52,8 @@ export default function ArtistCreation() {
         setLoading(true);
         setMessage('');
 
-        if (!formData.name.trim()) {
-            setMessage('Name des Künstlers ist erforderlich');
+        if (!validation.isValid()) {
+            setMessage('Bitte alle Pflichtfelder korrekt ausfüllen');
             setLoading(false);
             return;
         }
@@ -97,9 +112,13 @@ export default function ArtistCreation() {
                         name="name"
                         value={formData.name}
                         onChange={handleChange}
+                        className={validation.classFor('name', formData.name)}
                         required
                         style={{ width: '100%', padding: '0.5rem', borderRadius: '4px', border: '1px solid #ccc' }}
                     />
+                    {validation.errors.name && (
+                        <div className="validation-msg">{validation.errors.name}</div>
+                    )}
                 </div>
 
                 <div style={{ marginBottom: '1rem' }}>
@@ -126,9 +145,13 @@ export default function ArtistCreation() {
                         name="website"
                         value={formData.website}
                         onChange={handleChange}
+                        className={validation.classFor('website', formData.website)}
                         placeholder="https://example.com"
                         style={{ width: '100%', padding: '0.5rem', borderRadius: '4px', border: '1px solid #ccc' }}
                     />
+                    {validation.errors.website && (
+                        <div className="validation-msg">{validation.errors.website}</div>
+                    )}
                 </div>
 
                 <div style={{ marginBottom: '1rem' }}>
@@ -146,7 +169,7 @@ export default function ArtistCreation() {
 
                 <button
                     type="submit"
-                    disabled={loading}
+                    disabled={loading || !validation.isValid()}
                     style={{ width: '100%', padding: '0.75rem', backgroundColor: '#002b55', color: '#fff', border: 'none', borderRadius: '4px', cursor: 'pointer' }}
                 >
                     {loading ? 'Bitte warten...' : 'Künstler erstellen'}

--- a/eventim-disability-integration/src/pages/admin/countries/cities/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/cities/create.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useValidation } from '../../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../../hooks/useRequireAccess';
 
@@ -12,6 +13,7 @@ export default function CityCreation() {
     const [countries, setCountries] = useState([]);
     const [message, setMessage] = useState('');
     const [loading, setLoading] = useState(false);
+    const validation = useValidation({ name: '', countryId: '' });
 
     useEffect(() => {
         // Länder für Dropdown laden
@@ -24,6 +26,8 @@ export default function CityCreation() {
     const handleChange = e => {
         const { name, value } = e.target;
         setFormData(prev => ({ ...prev, [name]: value }));
+        if (name === 'name') validation.validate('name', value, { required: true });
+        if (name === 'countryId') validation.validate('countryId', value, { required: true });
     };
 
     const handleSubmit = async e => {
@@ -31,8 +35,8 @@ export default function CityCreation() {
         setLoading(true);
         setMessage('');
 
-        if (!formData.name.trim() || !formData.countryId) {
-            setMessage('Name und Land sind erforderlich');
+        if (!validation.isValid()) {
+            setMessage('Bitte alle Pflichtfelder korrekt ausfüllen');
             setLoading(false);
             return;
         }
@@ -84,9 +88,13 @@ export default function CityCreation() {
                         name="name"
                         value={formData.name}
                         onChange={handleChange}
+                        className={validation.classFor('name', formData.name)}
                         required
                         style={{ width: '100%', padding: '0.5rem', borderRadius: '4px', border: '1px solid #ccc' }}
                     />
+                    {validation.errors.name && (
+                        <div className="validation-msg">{validation.errors.name}</div>
+                    )}
                 </div>
 
                 <div style={{ marginBottom: '1rem' }}>
@@ -96,6 +104,7 @@ export default function CityCreation() {
                         name="countryId"
                         value={formData.countryId}
                         onChange={handleChange}
+                        className={validation.classFor('countryId', formData.countryId)}
                         required
                         style={{ width: '100%', padding: '0.5rem', borderRadius: '4px', border: '1px solid #ccc' }}
                     >
@@ -104,11 +113,14 @@ export default function CityCreation() {
                             <option key={c.id} value={c.id}>{c.name}</option>
                         ))}
                     </select>
+                    {validation.errors.countryId && (
+                        <div className="validation-msg">{validation.errors.countryId}</div>
+                    )}
                 </div>
 
                 <button
                     type="submit"
-                    disabled={loading}
+                    disabled={loading || !validation.isValid()}
                     style={{
                         backgroundColor: '#002b55',
                         color: 'white',

--- a/eventim-disability-integration/src/pages/admin/countries/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/create.jsx
@@ -1,5 +1,6 @@
 // country.jsx (in your Next.js pages or components folder)
 import React, { useState } from 'react';
+import { useValidation } from '../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 
@@ -9,10 +10,19 @@ export default function CountryCreation() {
     const [formData, setFormData] = useState({ name: '', code: '' });
     const [message, setMessage] = useState('');
     const [loading, setLoading] = useState(false);
+    const validation = useValidation({ name: '', code: '' });
 
     const handleChange = (e) => {
         const { name, value } = e.target;
         setFormData({ ...formData, [name]: value });
+        if (name === 'name') validation.validate('name', value, { required: true });
+        if (name === 'code' && value) {
+            validation.validate('code', value, {
+                pattern: /^[A-Za-z]{2}$/, message: 'Code muss 2 Buchstaben haben',
+            });
+        } else if (name === 'code') {
+            validation.validate('code', value);
+        }
     };
 
     const handleSubmit = async (e) => {
@@ -20,8 +30,8 @@ export default function CountryCreation() {
         setLoading(true);
         setMessage('');
 
-        if (!formData.name.trim()) {
-            setMessage('Name des Landes ist erforderlich');
+        if (!validation.isValid()) {
+            setMessage('Bitte alle Pflichtfelder korrekt ausfüllen');
             setLoading(false);
             return;
         }
@@ -78,9 +88,13 @@ export default function CountryCreation() {
                         name="name"
                         value={formData.name}
                         onChange={handleChange}
+                        className={validation.classFor('name', formData.name)}
                         required
                         style={{ width: '100%', padding: '0.5rem', borderRadius: '4px', border: '1px solid #ccc' }}
                     />
+                    {validation.errors.name && (
+                        <div className="validation-msg">{validation.errors.name}</div>
+                    )}
                 </div>
 
                 <div style={{ marginBottom: '1rem' }}>
@@ -93,14 +107,18 @@ export default function CountryCreation() {
                         name="code"
                         value={formData.code}
                         onChange={handleChange}
+                        className={validation.classFor('code', formData.code)}
                         placeholder="z.B. DE für Deutschland"
                         style={{ width: '100%', padding: '0.5rem', borderRadius: '4px', border: '1px solid #ccc' }}
                     />
+                    {validation.errors.code && (
+                        <div className="validation-msg">{validation.errors.code}</div>
+                    )}
                 </div>
 
                 <button
                     type="submit"
-                    disabled={loading}
+                    disabled={loading || !validation.isValid()}
                     style={{ width: '100%', padding: '0.75rem', backgroundColor: '#002b55', color: '#fff', border: 'none', borderRadius: '4px', cursor: 'pointer' }}
                 >
                     {loading ? 'Bitte warten...' : 'Land erstellen'}

--- a/eventim-disability-integration/src/pages/admin/genres/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/genres/create.jsx
@@ -1,5 +1,6 @@
 // genres.jsx
 import React, { useState } from 'react';
+import { useValidation } from '../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 
@@ -12,10 +13,12 @@ export default function GenreCreation() {
     const [subgenres, setSubgenres] = useState([]); // [{ name: '' }]
     const [message, setMessage] = useState('');
     const [loading, setLoading] = useState(false);
+    const validation = useValidation({ name: '' });
 
     const handleChange = (e) => {
         const { name, value } = e.target;
         setFormData((f) => ({ ...f, [name]: value }));
+        if (name === 'name') validation.validate('name', value, { required: true });
     };
 
     const addSubgenre = () => {
@@ -37,7 +40,7 @@ export default function GenreCreation() {
         setLoading(true);
         setMessage('');
 
-        if (!formData.name.trim()) {
+        if (!validation.isValid()) {
             setMessage('Bitte gib einen Genre-Namen an');
             setLoading(false);
             return;
@@ -120,6 +123,7 @@ export default function GenreCreation() {
                         name="name"
                         value={formData.name}
                         onChange={handleChange}
+                        className={validation.classFor('name', formData.name)}
                         required
                         style={{
                             width: '100%',
@@ -128,6 +132,9 @@ export default function GenreCreation() {
                             borderRadius: '4px',
                         }}
                     />
+                    {validation.errors.name && (
+                        <div className="validation-msg">{validation.errors.name}</div>
+                    )}
                 </div>
 
                 {/* Subgenres */}
@@ -196,7 +203,7 @@ export default function GenreCreation() {
                 {/* Submit */}
                 <button
                     type="submit"
-                    disabled={loading}
+                    disabled={loading || !validation.isValid()}
                     style={{
                         backgroundColor: '#002b55',
                         color: 'white',

--- a/eventim-disability-integration/src/pages/admin/tours/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/create.jsx
@@ -2,6 +2,7 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { useValidation } from '../../../hooks/useValidation';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 
 export default function TourCreation() {
@@ -27,6 +28,7 @@ export default function TourCreation() {
 
     const [message, setMessage] = useState("");
     const [loading, setLoading] = useState(false);
+    const validation = useValidation({ title: '', startDate: '', endDate: '' });
 
     // --------------------------------------------------
     // 2) Hook: Künstler & Genres laden
@@ -53,6 +55,9 @@ export default function TourCreation() {
             setFormData((prev) => ({ ...prev, [name]: files[0] }));
         } else {
             setFormData((prev) => ({ ...prev, [name]: value }));
+            if (name === 'title') validation.validate('title', value, { required: true });
+            if (name === 'startDate') validation.validate('startDate', value, { required: true });
+            if (name === 'endDate') validation.validate('endDate', value, { required: true });
         }
     };
 
@@ -152,9 +157,7 @@ export default function TourCreation() {
 
         // Pflichtprüfungen:
         if (
-            !formData.title.trim() ||
-            !formData.startDate ||
-            !formData.endDate ||
+            !validation.isValid() ||
             tourArtists.length === 0 ||
             tourArtists.some((aid) => !aid)
         ) {
@@ -278,6 +281,7 @@ export default function TourCreation() {
                         name="title"
                         value={formData.title}
                         onChange={handleChange}
+                        className={validation.classFor('title', formData.title)}
                         required
                         style={{
                             width: "100%",
@@ -286,6 +290,9 @@ export default function TourCreation() {
                             border: "1px solid #ccc",
                         }}
                     />
+                    {validation.errors.title && (
+                        <div className="validation-msg">{validation.errors.title}</div>
+                    )}
                 </div>
 
                 {/* === Beschreibung === */}
@@ -334,6 +341,7 @@ export default function TourCreation() {
                             name="startDate"
                             value={formData.startDate}
                             onChange={handleChange}
+                            className={validation.classFor('startDate', formData.startDate)}
                             required
                             style={{
                                 width: "100%",
@@ -342,6 +350,9 @@ export default function TourCreation() {
                                 border: "1px solid #ccc",
                             }}
                         />
+                        {validation.errors.startDate && (
+                            <div className="validation-msg">{validation.errors.startDate}</div>
+                        )}
                     </div>
                     <div style={{ flex: 1 }}>
                         <label
@@ -360,6 +371,7 @@ export default function TourCreation() {
                             name="endDate"
                             value={formData.endDate}
                             onChange={handleChange}
+                            className={validation.classFor('endDate', formData.endDate)}
                             required
                             style={{
                                 width: "100%",
@@ -368,6 +380,9 @@ export default function TourCreation() {
                                 border: "1px solid #ccc",
                             }}
                         />
+                        {validation.errors.endDate && (
+                            <div className="validation-msg">{validation.errors.endDate}</div>
+                        )}
                     </div>
                 </div>
 
@@ -620,7 +635,7 @@ export default function TourCreation() {
                 {/* === Submit-Button === */}
                 <button
                     type="submit"
-                    disabled={loading}
+                    disabled={loading || !validation.isValid()}
                     style={{
                         backgroundColor: "#002b55",
                         color: "white",

--- a/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
@@ -1,6 +1,7 @@
 // pages/events.jsx
 
 import React, { useState, useEffect } from 'react';
+import { useValidation } from '../../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../../hooks/useRequireAccess';
 
@@ -32,6 +33,7 @@ export default function EventCreation() {
 
     const [message, setMessage] = useState('');
     const [loading, setLoading] = useState(false);
+    const validation = useValidation({ tourId: '', venueId: '', doorTime: '', startTime: '', endTime: '' });
 
     // 1) Load tours, venues, artists
     useEffect(() => {
@@ -86,6 +88,9 @@ export default function EventCreation() {
     const handleChange = e => {
         const { name, value } = e.target;
         setFormData(f => ({ ...f, [name]: value }));
+        if (['tourId', 'venueId', 'doorTime', 'startTime', 'endTime'].includes(name)) {
+            validation.validate(name, value, { required: true });
+        }
     };
 
     // 3) Artist-Handler (unverändert)
@@ -180,7 +185,7 @@ export default function EventCreation() {
         setMessage('');
 
         const { tourId, venueId, doorTime, startTime, endTime } = formData;
-        if (!tourId || !venueId || !doorTime || !startTime || !endTime) {
+        if (!validation.isValid()) {
             setMessage('Tour, Venue und alle Zeiten sind erforderlich');
             setLoading(false);
             return;
@@ -353,6 +358,7 @@ export default function EventCreation() {
                         name="tourId"
                         value={formData.tourId}
                         onChange={handleChange}
+                        className={validation.classFor('tourId', formData.tourId)}
                         required
                         style={{
                             width: '100%',
@@ -381,6 +387,7 @@ export default function EventCreation() {
                         name="venueId"
                         value={formData.venueId}
                         onChange={handleChange}
+                        className={validation.classFor('venueId', formData.venueId)}
                         required
                         style={{
                             width: '100%',
@@ -410,6 +417,7 @@ export default function EventCreation() {
                         name="doorTime"
                         value={formData.doorTime}
                         onChange={handleChange}
+                        className={validation.classFor('doorTime', formData.doorTime)}
                         required
                         style={{
                             width: '100%',
@@ -432,6 +440,7 @@ export default function EventCreation() {
                         name="startTime"
                         value={formData.startTime}
                         onChange={handleChange}
+                        className={validation.classFor('startTime', formData.startTime)}
                         required
                         style={{
                             width: '100%',
@@ -440,6 +449,9 @@ export default function EventCreation() {
                             borderRadius: '4px'
                         }}
                     />
+                    {validation.errors.startTime && (
+                        <div className="validation-msg">{validation.errors.startTime}</div>
+                    )}
                 </div>
 
                 {/* ---------------- End Time ---------------- */}
@@ -454,6 +466,7 @@ export default function EventCreation() {
                         name="endTime"
                         value={formData.endTime}
                         onChange={handleChange}
+                        className={validation.classFor('endTime', formData.endTime)}
                         required
                         style={{
                             width: '100%',
@@ -462,6 +475,9 @@ export default function EventCreation() {
                             borderRadius: '4px'
                         }}
                     />
+                    {validation.errors.endTime && (
+                        <div className="validation-msg">{validation.errors.endTime}</div>
+                    )}
                 </div>
 
                 {/* ---------------- Description ---------------- */}
@@ -855,7 +871,7 @@ export default function EventCreation() {
                 {/* ---------------- Submit ---------------- */}
                 <button
                     type="submit"
-                    disabled={loading}
+                    disabled={loading || !validation.isValid()}
                     style={{
                         backgroundColor: '#002b55',
                         color: 'white',

--- a/eventim-disability-integration/src/pages/admin/venues/areas/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/areas/create.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState } from 'react';
+import { useValidation } from '../../../../hooks/useValidation';
 import { useRequireAccess } from '../../../../hooks/useRequireAccess';
 
 export default function AreaCreation() {
@@ -11,10 +12,12 @@ export default function AreaCreation() {
     });
     const [message, setMessage] = useState('');
     const [loading, setLoading] = useState(false);
+    const validation = useValidation({ name: '' });
 
     const handleChange = e => {
         const { name, value } = e.target;
         setFormData(f => ({ ...f, [name]: value }));
+        if (name === 'name') validation.validate('name', value, { required: true });
     };
 
     const handleSubmit = async e => {
@@ -23,7 +26,7 @@ export default function AreaCreation() {
         setLoading(true);
 
         const { name } = formData;
-        if (!name.trim()) {
+        if (!validation.isValid()) {
             setMessage('Name ist erforderlich');
             setLoading(false);
             return;
@@ -79,9 +82,13 @@ export default function AreaCreation() {
                         name="name"
                         value={formData.name}
                         onChange={handleChange}
+                        className={validation.classFor('name', formData.name)}
                         required
                         style={{ width: '100%', padding: '.5rem', border: '1px solid #ccc', borderRadius: '4px' }}
                     />
+                    {validation.errors.name && (
+                        <div className="validation-msg">{validation.errors.name}</div>
+                    )}
                 </div>
 
                 {/* Beschreibung */}
@@ -101,7 +108,7 @@ export default function AreaCreation() {
                 {/* Submit */}
                 <button
                     type="submit"
-                    disabled={loading}
+                    disabled={loading || !validation.isValid()}
                     style={{
                         backgroundColor: '#002b55',
                         color: 'white',

--- a/eventim-disability-integration/src/pages/admin/venues/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/create.jsx
@@ -1,5 +1,6 @@
 // venues.jsx (Next.js Komponente mit disability area capacities)
 import React, { useState, useEffect } from 'react';
+import { useValidation } from '../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 
@@ -18,6 +19,7 @@ export default function VenueCreation() {
     const [venueAreas, setVenueAreas] = useState([]); // [{ areaId, maxCapacity }]
     const [message, setMessage] = useState('');
     const [loading, setLoading] = useState(false);
+    const validation = useValidation({ name: '', address: '', cityId: '', website: '' });
 
     useEffect(() => {
         fetch('http://localhost:4000/cities')
@@ -32,6 +34,14 @@ export default function VenueCreation() {
             setFormData(f => ({ ...f, [name]: files[0] }));
         } else {
             setFormData(f => ({ ...f, [name]: value }));
+            if (name === 'name') validation.validate('name', value, { required: true });
+            if (name === 'address') validation.validate('address', value, { required: true });
+            if (name === 'cityId') validation.validate('cityId', value, { required: true });
+            if (name === 'website' && value) {
+                validation.validate('website', value, { pattern: /^https?:\/\//i, message: 'Ungültige URL' });
+            } else if (name === 'website') {
+                validation.validate('website', value);
+            }
         }
     };
 
@@ -49,7 +59,7 @@ export default function VenueCreation() {
         e.preventDefault();
         setLoading(true);
         setMessage('');
-        if (!formData.name.trim() || !formData.address.trim() || !formData.cityId) {
+        if (!validation.isValid()) {
             setMessage('Name, Adresse und Stadt sind erforderlich');
             setLoading(false);
             return;
@@ -106,36 +116,47 @@ export default function VenueCreation() {
                 <div style={{ marginBottom:'1rem' }}>
                     <label htmlFor="name" style={{ display:'block', fontWeight:'bold', marginBottom:'.5rem' }}>Name *</label>
                     <input id="name" name="name" type="text" value={formData.name}
-                           onChange={handleChange} required
+                           onChange={handleChange}
+                           className={validation.classFor('name', formData.name)}
+                           required
                            style={{ width:'100%', padding:'.5rem', borderRadius:'4px', border:'1px solid #ccc' }}
                     />
+                    {validation.errors.name && <div className="validation-msg">{validation.errors.name}</div>}
                 </div>
                 {/* Address */}
                 <div style={{ marginBottom:'1rem' }}>
                     <label htmlFor="address" style={{ display:'block', fontWeight:'bold', marginBottom:'.5rem' }}>Adresse *</label>
                     <input id="address" name="address" type="text" value={formData.address}
-                           onChange={handleChange} required
+                           onChange={handleChange}
+                           className={validation.classFor('address', formData.address)}
+                           required
                            style={{ width:'100%', padding:'.5rem', borderRadius:'4px', border:'1px solid #ccc' }}
                     />
+                    {validation.errors.address && <div className="validation-msg">{validation.errors.address}</div>}
                 </div>
                 {/* City */}
                 <div style={{ marginBottom:'1rem' }}>
                     <label htmlFor="cityId" style={{ display:'block', fontWeight:'bold', marginBottom:'.5rem' }}>Stadt *</label>
                     <select id="cityId" name="cityId" value={formData.cityId}
-                            onChange={handleChange} required
+                            onChange={handleChange}
+                            className={validation.classFor('cityId', formData.cityId)}
+                            required
                             style={{ width:'100%', padding:'.5rem', borderRadius:'4px', border:'1px solid #ccc' }}
                     >
                         <option value="">Bitte wählen</option>
                         {cities.map(c => <option key={c.id} value={c.id}>{c.name}</option>)}
                     </select>
+                    {validation.errors.cityId && <div className="validation-msg">{validation.errors.cityId}</div>}
                 </div>
                 {/* Website */}
                 <div style={{ marginBottom:'1rem' }}>
                     <label htmlFor="website" style={{ display:'block', fontWeight:'bold', marginBottom:'.5rem' }}>Website</label>
                     <input id="website" name="website" type="url" value={formData.website}
-                           onChange={handleChange} placeholder="https://example.com"
+                           onChange={handleChange}
+                           className={validation.classFor('website', formData.website)} placeholder="https://example.com"
                            style={{ width:'100%', padding:'.5rem', borderRadius:'4px', border:'1px solid #ccc' }}
                     />
+                    {validation.errors.website && <div className="validation-msg">{validation.errors.website}</div>}
                 </div>
                 {/* Venue Image */}
                 <div style={{ marginBottom:'1rem' }}>
@@ -180,7 +201,7 @@ export default function VenueCreation() {
                     </button>
                 </div>
                 {/* Submit */}
-                <button type="submit" disabled={loading}
+                <button type="submit" disabled={loading || !validation.isValid()}
                         style={{ backgroundColor:'#002b55', color:'white', padding:'0.75rem 1.5rem',
                             border:'none', borderRadius:'4px', fontSize:'1rem', cursor:'pointer', width:'100%' }}>
                     {loading?'Bitte warten...':'Venue erstellen'}

--- a/eventim-disability-integration/src/pages/login.jsx
+++ b/eventim-disability-integration/src/pages/login.jsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState } from 'react';
+import { useValidation } from '../hooks/useValidation';
 import { useRouter } from 'next/router';
 import DisabilityExpiredModal from '../components/DisabilityExpiredModal';
 
@@ -20,7 +21,22 @@ export default function LoginPage() {
     const [registerPassword, setRegisterPassword] = useState('');
     const [registerError, setRegisterError] = useState('');
 
+    const loginValidation = useValidation({ loginEmail: '', loginPassword: '' });
+    const registerValidation = useValidation({ registerEmail: '', registerPassword: '' });
+
     const isValidEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+
+    const checkEmailExists = async (email) => {
+        try {
+            const res = await fetch(
+                `http://localhost:4000/email-exists?email=${encodeURIComponent(email)}`
+            );
+            const data = await res.json();
+            return data.exists;
+        } catch {
+            return false;
+        }
+    };
 
     // 1) Login‐Handler: jetzt mit credentials: 'include'
     const handleLogin = async (e) => {
@@ -30,6 +46,10 @@ export default function LoginPage() {
 
         if (!loginEmail.trim() || !loginPassword.trim()) {
             setLoginError('Bitte E-Mail und Passwort eingeben.');
+            setLoginLoading(false);
+            return;
+        }
+        if (!loginValidation.isValid()) {
             setLoginLoading(false);
             return;
         }
@@ -103,6 +123,9 @@ export default function LoginPage() {
             setRegisterError('Bitte eine gültige E-Mail-Adresse eingeben.');
             return;
         }
+        if (!registerValidation.isValid()) {
+            return;
+        }
         sessionStorage.setItem('preRegEmail', registerEmail.trim());
         sessionStorage.setItem('preRegPassword', registerPassword);
         const redirectParam = redirect
@@ -158,12 +181,33 @@ export default function LoginPage() {
                                 type="email"
                                 id="loginEmail"
                                 name="loginEmail"
-                                className="input"
+                                className={`input ${loginValidation.classFor('loginEmail', loginEmail)}`}
                                 placeholder="E-Mail-Adresse eingeben"
                                 value={loginEmail}
-                                onChange={(e) => setLoginEmail(e.target.value)}
+                                onChange={(e) => {
+                                    setLoginEmail(e.target.value);
+                                    loginValidation.validate('loginEmail', e.target.value, {
+                                        required: true,
+                                        pattern: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                                        message:
+                                            'Die E-Mail muss in einem validen E-Mail Format (bspw. Max.Mustermann@test.de) vorliegen',
+                                    });
+                                }}
+                                onBlur={(e) =>
+                                    loginValidation.validate('loginEmail', e.target.value, {
+                                        required: true,
+                                        pattern: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                                        message:
+                                            'Die E-Mail muss in einem validen E-Mail Format (bspw. Max.Mustermann@test.de) vorliegen',
+                                    })
+                                }
                                 required
                             />
+                            {loginValidation.errors.loginEmail && (
+                                <div className="validation-msg">
+                                    {loginValidation.errors.loginEmail}
+                                </div>
+                            )}
                         </div>
                         <div className="form-group">
                             <label htmlFor="loginPassword" className="label">
@@ -173,12 +217,21 @@ export default function LoginPage() {
                                 type="password"
                                 id="loginPassword"
                                 name="loginPassword"
-                                className="input"
+                                className={`input ${loginValidation.classFor('loginPassword', loginPassword)}`}
                                 placeholder="Passwort eingeben"
                                 value={loginPassword}
-                                onChange={(e) => setLoginPassword(e.target.value)}
+                                onChange={(e) => {
+                                    setLoginPassword(e.target.value);
+                                    loginValidation.validate('loginPassword', e.target.value, { required: true });
+                                }}
+                                onBlur={(e) => loginValidation.validate('loginPassword', e.target.value, { required: true })}
                                 required
                             />
+                            {loginValidation.errors.loginPassword && (
+                                <div className="validation-msg">
+                                    {loginValidation.errors.loginPassword}
+                                </div>
+                            )}
                         </div>
                         <div className="form-footer">
                             <a href="#" className="link-forgot">
@@ -188,7 +241,7 @@ export default function LoginPage() {
                         <button
                             type="submit"
                             className="button-primary"
-                            disabled={loginLoading}
+                            disabled={loginLoading || !loginValidation.isValid()}
                         >
                             {loginLoading ? 'Bitte warten...' : 'Anmelden'}
                         </button>
@@ -218,12 +271,41 @@ export default function LoginPage() {
                                 type="email"
                                 id="registerEmail"
                                 name="registerEmail"
-                                className="input"
+                                className={`input ${registerValidation.classFor('registerEmail', registerEmail)}`}
                                 placeholder="E-Mail-Adresse eingeben"
                                 value={registerEmail}
-                                onChange={(e) => setRegisterEmail(e.target.value)}
+                                onChange={(e) => {
+                                    setRegisterEmail(e.target.value);
+                                    registerValidation.validate('registerEmail', e.target.value, {
+                                        required: true,
+                                        pattern: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                                        message:
+                                            'Die E-Mail muss in einem validen E-Mail Format (bspw. Max.Mustermann@test.de) vorliegen',
+                                    });
+                                }}
+                                onBlur={async (e) => {
+                                    const value = e.target.value;
+                                    const valid = registerValidation.validate('registerEmail', value, {
+                                        required: true,
+                                        pattern: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                                        message:
+                                            'Die E-Mail muss in einem validen E-Mail Format (bspw. Max.Mustermann@test.de) vorliegen',
+                                    });
+                                    if (valid && (await checkEmailExists(value))) {
+                                        registerValidation.validate('registerEmail', value, {
+                                            required: true,
+                                            pattern: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                                            message: 'Diese E-Mail ist bereits registriert.',
+                                        });
+                                    }
+                                }}
                                 required
                             />
+                            {registerValidation.errors.registerEmail && (
+                                <div className="validation-msg">
+                                    {registerValidation.errors.registerEmail}
+                                </div>
+                            )}
                         </div>
                         <div className="form-group">
                             <label htmlFor="registerPassword" className="label">
@@ -233,12 +315,31 @@ export default function LoginPage() {
                                 type="password"
                                 id="registerPassword"
                                 name="registerPassword"
-                                className="input"
+                                className={`input ${registerValidation.classFor('registerPassword', registerPassword)}`}
                                 placeholder="Neues Passwort eingeben"
                                 value={registerPassword}
-                                onChange={(e) => setRegisterPassword(e.target.value)}
+                                onChange={(e) => {
+                                    setRegisterPassword(e.target.value);
+                                    registerValidation.validate('registerPassword', e.target.value, {
+                                        required: true,
+                                        pattern: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}$/,
+                                        message: 'Passwort zu schwach',
+                                    });
+                                }}
+                                onBlur={(e) =>
+                                    registerValidation.validate('registerPassword', e.target.value, {
+                                        required: true,
+                                        pattern: /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}$/,
+                                        message: 'Passwort zu schwach',
+                                    })
+                                }
                                 required
                             />
+                            {registerValidation.errors.registerPassword && (
+                                <div className="validation-msg">
+                                    {registerValidation.errors.registerPassword}
+                                </div>
+                            )}
                         </div>
                         <p className="info-text">
                             Bitte gib mindestens acht Zeichen ein, es müssen Buchstaben (Groß- und
@@ -251,7 +352,11 @@ export default function LoginPage() {
                             </a>{' '}
                             nachlesen.
                         </p>
-                        <button type="submit" className="button-primary">
+                        <button
+                            type="submit"
+                            className="button-primary"
+                            disabled={!registerValidation.isValid()}
+                        >
                             Weiter
                         </button>
                     </form>

--- a/eventim-disability-integration/src/pages/registration.jsx
+++ b/eventim-disability-integration/src/pages/registration.jsx
@@ -1,6 +1,7 @@
 // src/pages/registration.jsx
 
 import React, { useState, useEffect } from 'react';
+import { useValidation } from '../hooks/useValidation';
 import { useRouter } from 'next/router';
 
 export default function Registration() {
@@ -38,6 +39,13 @@ export default function Registration() {
 
     const [message, setMessage] = useState('');
     const [loading, setLoading] = useState(false);
+    const validation = useValidation({
+        firstName: '',
+        lastName: '',
+        email: '',
+        password: '',
+        confirmPassword: ''
+    });
 
     // 1) Prefill email/password from sessionStorage if present (unchanged)
     useEffect(() => {
@@ -105,6 +113,27 @@ export default function Registration() {
                 ...formData,
                 [name]: value,
             });
+            if (['firstName', 'lastName', 'email', 'password', 'confirmPassword'].includes(name)) {
+                const opts = { required: true };
+                if (name === 'email') {
+                    opts.pattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+                    opts.message =
+                        'Die E-Mail muss in einem validen E-Mail Format (bspw. Max.Mustermann@test.de) vorliegen';
+                }
+                if (name === 'password') {
+                    opts.pattern = /^(?=.*[A-Za-z])(?=.*\d)(?=.*[^A-Za-z\d]).{8,}$/;
+                    opts.message = 'Passwort zu schwach';
+                }
+                if (name === 'confirmPassword') {
+                    if (value !== formData.password) {
+                        validation.validate('confirmPassword', value, { required: true, message: 'Passwörter stimmen nicht überein' });
+                    } else {
+                        validation.validate('confirmPassword', value, { required: true });
+                    }
+                } else {
+                    validation.validate(name, value, opts);
+                }
+            }
         }
     };
 
@@ -141,6 +170,12 @@ export default function Registration() {
         e.preventDefault();
         setLoading(true);
         setMessage('');
+
+        if (!validation.isValid()) {
+            setLoading(false);
+            setMessage('Bitte alle Pflichtfelder korrekt ausfüllen');
+            return;
+        }
 
         // 1) Passwords match?
         if (formData.password !== formData.confirmPassword) {
@@ -263,6 +298,7 @@ export default function Registration() {
                         name="firstName"
                         value={formData.firstName}
                         onChange={handleChange}
+                        className={validation.classFor('firstName', formData.firstName)}
                         required
                         style={{
                             width: '100%',
@@ -271,6 +307,11 @@ export default function Registration() {
                             border: '1px solid #ccc',
                         }}
                     />
+                    {validation.errors.firstName && (
+                        <div className="validation-msg">
+                            {validation.errors.firstName}
+                        </div>
+                    )}
                 </div>
 
                 {/* ---------------- Nachname ---------------- */}
@@ -287,6 +328,7 @@ export default function Registration() {
                         name="lastName"
                         value={formData.lastName}
                         onChange={handleChange}
+                        className={validation.classFor('lastName', formData.lastName)}
                         required
                         style={{
                             width: '100%',
@@ -295,6 +337,11 @@ export default function Registration() {
                             border: '1px solid #ccc',
                         }}
                     />
+                    {validation.errors.lastName && (
+                        <div className="validation-msg">
+                            {validation.errors.lastName}
+                        </div>
+                    )}
                 </div>
 
                 {/* ---------------- Firma ---------------- */}
@@ -623,7 +670,7 @@ export default function Registration() {
                 {/* ---------------- Submit Button ---------------- */}
                 <button
                     type="submit"
-                    disabled={loading}
+                    disabled={loading || !validation.isValid()}
                     style={{
                         backgroundColor: '#002b55',
                         color: 'white',

--- a/eventim-disability-integration/src/styles/global.css
+++ b/eventim-disability-integration/src/styles/global.css
@@ -51,3 +51,7 @@ body, html {
     object-fit: cover;
     border-radius: 4px;
 }
+.input-valid { border: 1px solid #28a745; }
+.input-invalid { border: 1px solid #dc3545; }
+.validation-msg { color: #dc3545; font-size: 0.875rem; margin-top: 0.25rem; }
+


### PR DESCRIPTION
## Summary
- add `useValidation` hook for form input validation
- highlight valid/invalid fields on /login, /registration and admin create forms
- check existing emails via new `/email-exists` endpoint
- disable submits until validation passes

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686259b4ea90833088f5192ec8077a79