### PR TITLE
Add admin overview pages for countries and genres

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -1648,6 +1648,37 @@ app.get('/genres-with-subgenres', async (req, res) => {
     }
 });
 
+app.get('/countries-with-cities', async (req, res) => {
+    try {
+        const { rows } = await client.query(`
+      SELECT
+        co.id AS country_id,
+        co.name AS country_name,
+        COALESCE(
+          json_agg(
+            json_build_object('id', ci.id, 'name', ci.name)
+          ) FILTER (WHERE ci.id IS NOT NULL),
+          '[]'
+        ) AS cities
+      FROM countries co
+      LEFT JOIN cities ci ON ci.country_id = co.id
+      GROUP BY co.id, co.name
+      ORDER BY co.name
+    `);
+
+        const countriesWithCities = rows.map(r => ({
+            id: r.country_id,
+            name: r.country_name,
+            cities: r.cities,
+        }));
+
+        return res.status(200).json({ countries: countriesWithCities });
+    } catch (error) {
+        console.error('Error fetching countries with cities:', error);
+        return res.status(500).json({ message: 'Fehler beim Laden der Länder und Städte' });
+    }
+});
+
 app.get('/cities-with-venues', async (req, res) => {
     try {
         const { rows } = await client.query(`

--- a/eventim-disability-integration/src/pages/admin/countries/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/index.jsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import FilterBar from '../../../components/filter-bar';
+import { useRouter } from 'next/router';
+import { API_BASE_URL } from '../../../config';
+import { useAuth } from '../../../hooks/useAuth';
+
+export default function CountriesContent() {
+    const [countries, setCountries] = useState([]);
+    const [filteredCountries, setFilteredCountries] = useState([]);
+
+    const router = useRouter();
+    const { user } = useAuth();
+
+    const filterFields = [{ key: 'name', label: 'Name', match: 'startsWith' }];
+
+    useEffect(() => {
+        fetchCountries();
+    }, []);
+
+    const fetchCountries = async () => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/countries-with-cities`);
+            if (!res.ok) throw new Error();
+            const j = await res.json();
+            const arr = Array.isArray(j.countries) ? j.countries : [];
+            setCountries(arr);
+            setFilteredCountries(arr);
+        } catch (err) {
+            console.error('Fehler beim Laden der Länder:', err);
+            setCountries([]);
+            setFilteredCountries([]);
+        }
+    };
+
+    return (
+        <div className="artists-wrapper">
+            <div className="artists-header">
+                <h2 className="artists-title">Übersicht – Länder</h2>
+                {user?.hasCreationAccess && (
+                    <button
+                        className="btn-create-entity"
+                        onClick={() => router.push('/admin/countries/create')}
+                    >
+                        + Land erstellen
+                    </button>
+                )}
+            </div>
+
+            <div className="filter-container">
+                <FilterBar
+                    items={countries}
+                    onFiltered={setFilteredCountries}
+                    entityName="Land"
+                    entityRoute="countries"
+                    filterFields={filterFields}
+                />
+            </div>
+
+            <div className="artists-grid">
+                {filteredCountries.length === 0 && (
+                    <div className="no-artists">Keine Länder vorhanden.</div>
+                )}
+                {filteredCountries.map((country) => (
+                    <div className="artist-card" key={country.id}>
+                        <div className="card-header">
+                            <h3 className="artist-name">{country.name}</h3>
+                        </div>
+                        <div className="card-body">
+                            <div className="details-wrapper">
+                                {country.cities && country.cities.length > 0 ? (
+                                    <ul className="sub-list">
+                                        {country.cities.map((c) => (
+                                            <li key={c.id} className="sub-item">
+                                                {c.name}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                ) : (
+                                    <p className="artist-bio">Keine Städte vorhanden.</p>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+

--- a/eventim-disability-integration/src/pages/admin/genres/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/genres/index.jsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import FilterBar from '../../../components/filter-bar';
+import { useRouter } from 'next/router';
+import { API_BASE_URL } from '../../../config';
+import { useAuth } from '../../../hooks/useAuth';
+
+export default function GenresContent() {
+    const [genres, setGenres] = useState([]);
+    const [filteredGenres, setFilteredGenres] = useState([]);
+
+    const router = useRouter();
+    const { user } = useAuth();
+
+    const filterFields = [{ key: 'name', label: 'Name', match: 'startsWith' }];
+
+    useEffect(() => {
+        fetchGenres();
+    }, []);
+
+    const fetchGenres = async () => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/genres-with-subgenres`);
+            if (!res.ok) throw new Error();
+            const j = await res.json();
+            const arr = Array.isArray(j.genres) ? j.genres : [];
+            setGenres(arr);
+            setFilteredGenres(arr);
+        } catch (err) {
+            console.error('Fehler beim Laden der Genres:', err);
+            setGenres([]);
+            setFilteredGenres([]);
+        }
+    };
+
+    return (
+        <div className="artists-wrapper">
+            <div className="artists-header">
+                <h2 className="artists-title">Übersicht – Genres</h2>
+                {user?.hasCreationAccess && (
+                    <button
+                        className="btn-create-entity"
+                        onClick={() => router.push('/admin/genres/create')}
+                    >
+                        + Genre erstellen
+                    </button>
+                )}
+            </div>
+
+            <div className="filter-container">
+                <FilterBar
+                    items={genres}
+                    onFiltered={setFilteredGenres}
+                    entityName="Genre"
+                    entityRoute="genres"
+                    filterFields={filterFields}
+                />
+            </div>
+
+            <div className="artists-grid">
+                {filteredGenres.length === 0 && (
+                    <div className="no-artists">Keine Genres vorhanden.</div>
+                )}
+                {filteredGenres.map((genre) => (
+                    <div className="artist-card" key={genre.id}>
+                        <div className="card-header">
+                            <h3 className="artist-name">{genre.name}</h3>
+                        </div>
+                        <div className="card-body">
+                            <div className="details-wrapper">
+                                {genre.subgenres && genre.subgenres.length > 0 ? (
+                                    <ul className="sub-list">
+                                        {genre.subgenres.map((s) => (
+                                            <li key={s.id} className="sub-item">
+                                                {s.name}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                ) : (
+                                    <p className="artist-bio">Keine Subgenres vorhanden.</p>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+

--- a/eventim-disability-integration/src/styles/artists.css
+++ b/eventim-disability-integration/src/styles/artists.css
@@ -317,3 +317,15 @@
         margin-bottom: 0.75rem;
     }
 }
+
+/* ------------------------------------------------
+   14) Sub-Lists for Countries/Genres
+------------------------------------------------ */
+.sub-list {
+    list-style: none;
+    padding-left: 1rem;
+}
+.sub-item {
+    font-size: 0.875rem;
+    color: #333;
+}


### PR DESCRIPTION
## Summary
- implement API endpoint `countries-with-cities`
- add admin pages listing countries with their cities and genres with subgenres
- add small CSS classes for listing sub items

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68626e640d808330afa45d6d121cf478