### PR TITLE
Enable editing of countries and genres

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -737,6 +737,76 @@ app.get('/countries', async (req, res) => {
     }
 });
 
+// PUT: update country incl. its cities
+app.put('/countries/:id', async (req, res) => {
+    const countryId = req.params.id;
+    const { name, code, cities = [] } = req.body;
+
+    if (!name || !name.trim()) {
+        return res.status(400).json({ message: 'Name ist erforderlich' });
+    }
+
+    try {
+        await client.query('BEGIN');
+
+        await client.query(
+            `UPDATE countries
+                 SET name = $1,
+                     iso_code = $2
+               WHERE id = $3`,
+            [name.trim(), code ? code.trim().toUpperCase() : null, countryId]
+        );
+
+        const { rows: existing } = await client.query(
+            'SELECT id FROM cities WHERE country_id = $1',
+            [countryId]
+        );
+        const remaining = new Set(existing.map(r => r.id));
+
+        for (const c of cities) {
+            if (c.id && remaining.has(c.id)) {
+                await client.query(
+                    'UPDATE cities SET name = $1 WHERE id = $2',
+                    [c.name.trim(), c.id]
+                );
+                remaining.delete(c.id);
+            } else if (!c.id) {
+                await client.query(
+                    'INSERT INTO cities (id, name, country_id) VALUES ($1, $2, $3)',
+                    [uuidv4(), c.name.trim(), countryId]
+                );
+            }
+        }
+
+        for (const delId of remaining) {
+            await client.query('DELETE FROM cities WHERE id = $1', [delId]);
+        }
+
+        await client.query('COMMIT');
+        res.status(200).json({ message: 'Land aktualisiert' });
+    } catch (err) {
+        await client.query('ROLLBACK');
+        console.error('Update-country error:', err);
+        res.status(500).json({ message: 'Serverfehler beim Aktualisieren des Landes' });
+    }
+});
+
+// DELETE: remove country and its cities
+app.delete('/countries/:id', async (req, res) => {
+    const countryId = req.params.id;
+    try {
+        await client.query('BEGIN');
+        await client.query('DELETE FROM cities WHERE country_id = $1', [countryId]);
+        await client.query('DELETE FROM countries WHERE id = $1', [countryId]);
+        await client.query('COMMIT');
+        res.status(200).json({ message: 'Land gelöscht' });
+    } catch (err) {
+        await client.query('ROLLBACK');
+        console.error('Delete-country error:', err);
+        res.status(500).json({ message: 'Serverfehler beim Löschen des Landes' });
+    }
+});
+
 app.get('/email-exists', async (req, res) => {
     const email = req.query.email;
     if (!email) return res.status(400).json({ message: 'Email erforderlich' });
@@ -1609,6 +1679,73 @@ app.post('/create-genre', async (req, res) => {
     }
 });
 
+// PUT: update a genre and its subgenres
+app.put('/genres/:id', async (req, res) => {
+    const genreId = req.params.id;
+    const { name, subgenres = [] } = req.body;
+
+    if (!name || !name.trim()) {
+        return res.status(400).json({ message: 'Name ist erforderlich' });
+    }
+
+    try {
+        await client.query('BEGIN');
+
+        await client.query(
+            'UPDATE genres SET name = $1 WHERE id = $2',
+            [name.trim(), genreId]
+        );
+
+        const { rows: existing } = await client.query(
+            'SELECT id FROM subgenres WHERE genre_id = $1',
+            [genreId]
+        );
+        const remaining = new Set(existing.map(r => r.id));
+
+        for (const sg of subgenres) {
+            if (sg.id && remaining.has(sg.id)) {
+                await client.query(
+                    'UPDATE subgenres SET name = $1 WHERE id = $2',
+                    [sg.name.trim(), sg.id]
+                );
+                remaining.delete(sg.id);
+            } else if (!sg.id) {
+                await client.query(
+                    'INSERT INTO subgenres (id, genre_id, name) VALUES ($1, $2, $3)',
+                    [uuidv4(), genreId, sg.name.trim()]
+                );
+            }
+        }
+
+        for (const delId of remaining) {
+            await client.query('DELETE FROM subgenres WHERE id = $1', [delId]);
+        }
+
+        await client.query('COMMIT');
+        res.status(200).json({ message: 'Genre aktualisiert' });
+    } catch (err) {
+        await client.query('ROLLBACK');
+        console.error('Update-genre error:', err);
+        res.status(500).json({ message: 'Serverfehler beim Aktualisieren des Genres' });
+    }
+});
+
+// DELETE: remove a genre completely
+app.delete('/genres/:id', async (req, res) => {
+    const genreId = req.params.id;
+    try {
+        await client.query('BEGIN');
+        await client.query('DELETE FROM subgenres WHERE genre_id = $1', [genreId]);
+        await client.query('DELETE FROM genres WHERE id = $1', [genreId]);
+        await client.query('COMMIT');
+        res.status(200).json({ message: 'Genre gelöscht' });
+    } catch (err) {
+        await client.query('ROLLBACK');
+        console.error('Delete-genre error:', err);
+        res.status(500).json({ message: 'Serverfehler beim Löschen des Genres' });
+    }
+});
+
 app.get('/genres-with-subgenres', async (req, res) => {
     try {
         // 1) Fetch each genre, plus its subgenres in a single query.
@@ -1654,6 +1791,7 @@ app.get('/countries-with-cities', async (req, res) => {
       SELECT
         co.id AS country_id,
         co.name AS country_name,
+        co.iso_code      AS iso_code,
         COALESCE(
           json_agg(
             json_build_object('id', ci.id, 'name', ci.name)
@@ -1662,13 +1800,14 @@ app.get('/countries-with-cities', async (req, res) => {
         ) AS cities
       FROM countries co
       LEFT JOIN cities ci ON ci.country_id = co.id
-      GROUP BY co.id, co.name
+      GROUP BY co.id, co.name, co.iso_code
       ORDER BY co.name
     `);
 
         const countriesWithCities = rows.map(r => ({
             id: r.country_id,
             name: r.country_name,
+            iso_code: r.iso_code,
             cities: r.cities,
         }));
 

--- a/eventim-disability-integration/src/pages/admin/countries/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/index.jsx
@@ -7,6 +7,14 @@ import { useAuth } from '../../../hooks/useAuth';
 export default function CountriesContent() {
     const [countries, setCountries] = useState([]);
     const [filteredCountries, setFilteredCountries] = useState([]);
+    const [editingId, setEditingId] = useState(null);
+    const [editedData, setEditedData] = useState({
+        id: '',
+        name: '',
+        code: '',
+        cities: [],
+    });
+    const [confirmDeleteId, setConfirmDeleteId] = useState(null);
 
     const router = useRouter();
     const { user } = useAuth();
@@ -29,6 +37,77 @@ export default function CountriesContent() {
             console.error('Fehler beim Laden der Länder:', err);
             setCountries([]);
             setFilteredCountries([]);
+        }
+    };
+
+    const handleEditToggle = (country) => {
+        setEditingId(country.id);
+        setEditedData({
+            id: country.id,
+            name: country.name || '',
+            code: country.iso_code || '',
+            cities: Array.isArray(country.cities)
+                ? country.cities.map((c) => ({ id: c.id, name: c.name }))
+                : [],
+        });
+    };
+
+    const handleInputChange = (e) => {
+        const { name, value } = e.target;
+        setEditedData((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const addCity = () => {
+        setEditedData((prev) => ({
+            ...prev,
+            cities: [...prev.cities, { id: null, name: '' }],
+        }));
+    };
+
+    const updateCity = (index, value) => {
+        setEditedData((prev) => ({
+            ...prev,
+            cities: prev.cities.map((c, i) => (i === index ? { ...c, name: value } : c)),
+        }));
+    };
+
+    const removeCity = (index) => {
+        setEditedData((prev) => ({
+            ...prev,
+            cities: prev.cities.filter((_, i) => i !== index),
+        }));
+    };
+
+    const handleSave = async () => {
+        try {
+            const payload = {
+                name: editedData.name,
+                code: editedData.code,
+                cities: editedData.cities,
+            };
+            const response = await fetch(`${API_BASE_URL}/countries/${editedData.id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            });
+            if (!response.ok) throw new Error('Server-Fehler beim Speichern');
+            setEditingId(null);
+            fetchCountries();
+        } catch (err) {
+            console.error('Fehler beim Speichern:', err);
+        }
+    };
+
+    const handleDelete = async (id) => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/countries/${id}`, {
+                method: 'DELETE',
+            });
+            if (!res.ok) throw new Error('Server-Fehler beim Löschen');
+            setConfirmDeleteId(null);
+            fetchCountries();
+        } catch (err) {
+            console.error('Fehler beim Löschen:', err);
         }
     };
 
@@ -63,11 +142,74 @@ export default function CountriesContent() {
                 {filteredCountries.map((country) => (
                     <div className="artist-card" key={country.id}>
                         <div className="card-header">
-                            <h3 className="artist-name">{country.name}</h3>
+                            {editingId === country.id ? (
+                                <input
+                                    type="text"
+                                    name="name"
+                                    value={editedData.name}
+                                    onChange={handleInputChange}
+                                    className="input-name"
+                                />
+                            ) : (
+                                <h3 className="artist-name">{country.name}</h3>
+                            )}
+
+                            {editingId === country.id ? (
+                                <button className="btn-save" onClick={handleSave} title="Speichern">
+                                    💾
+                                </button>
+                            ) : (
+                                user?.hasEditingAccess && (
+                                    <button
+                                        className="btn-edit"
+                                        onClick={() => handleEditToggle(country)}
+                                        title="Bearbeiten"
+                                    >
+                                        ✎
+                                    </button>
+                                )
+                            )}
                         </div>
+
                         <div className="card-body">
                             <div className="details-wrapper">
-                                {country.cities && country.cities.length > 0 ? (
+                                {editingId === country.id ? (
+                                    <>
+                                        <input
+                                            type="text"
+                                            name="code"
+                                            value={editedData.code}
+                                            onChange={handleInputChange}
+                                            placeholder="ISO-Code"
+                                            className="input-website"
+                                        />
+
+                                        {editedData.cities.map((c, i) => (
+                                            <div
+                                                key={i}
+                                                style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.25rem' }}
+                                            >
+                                                <input
+                                                    type="text"
+                                                    value={c.name}
+                                                    onChange={(e) => updateCity(i, e.target.value)}
+                                                    className="input-website"
+                                                    style={{ flex: 1 }}
+                                                />
+                                                <button
+                                                    type="button"
+                                                    onClick={() => removeCity(i)}
+                                                    style={{ background: 'transparent', border: 'none', color: '#c00' }}
+                                                >
+                                                    ✕
+                                                </button>
+                                            </div>
+                                        ))}
+                                        <button type="button" onClick={addCity} className="btn-create-entity">
+                                            + Stadt hinzufügen
+                                        </button>
+                                    </>
+                                ) : country.cities && country.cities.length > 0 ? (
                                     <ul className="sub-list">
                                         {country.cities.map((c) => (
                                             <li key={c.id} className="sub-item">
@@ -80,6 +222,33 @@ export default function CountriesContent() {
                                 )}
                             </div>
                         </div>
+
+                        {editingId !== country.id && user?.hasDeletionPermission && (
+                            <button
+                                className="btn-edit"
+                                style={{ marginLeft: 'auto', marginRight: '0.5rem' }}
+                                onClick={() => setConfirmDeleteId(country.id)}
+                                title="Löschen"
+                            >
+                                🗑
+                            </button>
+                        )}
+
+                        {confirmDeleteId === country.id && user?.hasDeletionPermission && (
+                            <div className="modal-overlay">
+                                <div className="modal-box">
+                                    <p>Möchtest du dieses Land wirklich löschen?</p>
+                                    <div className="modal-actions">
+                                        <button className="btn btn-confirm" onClick={() => handleDelete(country.id)}>
+                                            Ja, löschen
+                                        </button>
+                                        <button className="btn btn-cancel" onClick={() => setConfirmDeleteId(null)}>
+                                            Abbrechen
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
                     </div>
                 ))}
             </div>

--- a/eventim-disability-integration/src/pages/admin/genres/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/genres/index.jsx
@@ -7,6 +7,13 @@ import { useAuth } from '../../../hooks/useAuth';
 export default function GenresContent() {
     const [genres, setGenres] = useState([]);
     const [filteredGenres, setFilteredGenres] = useState([]);
+    const [editingId, setEditingId] = useState(null);
+    const [editedData, setEditedData] = useState({
+        id: '',
+        name: '',
+        subgenres: [],
+    });
+    const [confirmDeleteId, setConfirmDeleteId] = useState(null);
 
     const router = useRouter();
     const { user } = useAuth();
@@ -29,6 +36,70 @@ export default function GenresContent() {
             console.error('Fehler beim Laden der Genres:', err);
             setGenres([]);
             setFilteredGenres([]);
+        }
+    };
+
+    const handleEditToggle = (genre) => {
+        setEditingId(genre.id);
+        setEditedData({
+            id: genre.id,
+            name: genre.name || '',
+            subgenres: Array.isArray(genre.subgenres)
+                ? genre.subgenres.map((s) => ({ id: s.id, name: s.name }))
+                : [],
+        });
+    };
+
+    const handleInputChange = (e) => {
+        const { name, value } = e.target;
+        setEditedData((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const addSub = () => {
+        setEditedData((prev) => ({
+            ...prev,
+            subgenres: [...prev.subgenres, { id: null, name: '' }],
+        }));
+    };
+
+    const updateSub = (idx, val) => {
+        setEditedData((prev) => ({
+            ...prev,
+            subgenres: prev.subgenres.map((s, i) => (i === idx ? { ...s, name: val } : s)),
+        }));
+    };
+
+    const removeSub = (idx) => {
+        setEditedData((prev) => ({
+            ...prev,
+            subgenres: prev.subgenres.filter((_, i) => i !== idx),
+        }));
+    };
+
+    const handleSave = async () => {
+        try {
+            const payload = { name: editedData.name, subgenres: editedData.subgenres };
+            const response = await fetch(`${API_BASE_URL}/genres/${editedData.id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            });
+            if (!response.ok) throw new Error('Server-Fehler beim Speichern');
+            setEditingId(null);
+            fetchGenres();
+        } catch (err) {
+            console.error('Fehler beim Speichern:', err);
+        }
+    };
+
+    const handleDelete = async (id) => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/genres/${id}`, { method: 'DELETE' });
+            if (!res.ok) throw new Error('Server-Fehler beim Löschen');
+            setConfirmDeleteId(null);
+            fetchGenres();
+        } catch (err) {
+            console.error('Fehler beim Löschen:', err);
         }
     };
 
@@ -63,11 +134,65 @@ export default function GenresContent() {
                 {filteredGenres.map((genre) => (
                     <div className="artist-card" key={genre.id}>
                         <div className="card-header">
-                            <h3 className="artist-name">{genre.name}</h3>
+                            {editingId === genre.id ? (
+                                <input
+                                    type="text"
+                                    name="name"
+                                    value={editedData.name}
+                                    onChange={handleInputChange}
+                                    className="input-name"
+                                />
+                            ) : (
+                                <h3 className="artist-name">{genre.name}</h3>
+                            )}
+
+                            {editingId === genre.id ? (
+                                <button className="btn-save" onClick={handleSave} title="Speichern">
+                                    💾
+                                </button>
+                            ) : (
+                                user?.hasEditingAccess && (
+                                    <button
+                                        className="btn-edit"
+                                        onClick={() => handleEditToggle(genre)}
+                                        title="Bearbeiten"
+                                    >
+                                        ✎
+                                    </button>
+                                )
+                            )}
                         </div>
+
                         <div className="card-body">
                             <div className="details-wrapper">
-                                {genre.subgenres && genre.subgenres.length > 0 ? (
+                                {editingId === genre.id ? (
+                                    <>
+                                        {editedData.subgenres.map((s, i) => (
+                                            <div
+                                                key={i}
+                                                style={{ display: 'flex', gap: '0.5rem', marginBottom: '0.25rem' }}
+                                            >
+                                                <input
+                                                    type="text"
+                                                    value={s.name}
+                                                    onChange={(e) => updateSub(i, e.target.value)}
+                                                    className="input-website"
+                                                    style={{ flex: 1 }}
+                                                />
+                                                <button
+                                                    type="button"
+                                                    onClick={() => removeSub(i)}
+                                                    style={{ background: 'transparent', border: 'none', color: '#c00' }}
+                                                >
+                                                    ✕
+                                                </button>
+                                            </div>
+                                        ))}
+                                        <button type="button" onClick={addSub} className="btn-create-entity">
+                                            + Subgenre hinzufügen
+                                        </button>
+                                    </>
+                                ) : genre.subgenres && genre.subgenres.length > 0 ? (
                                     <ul className="sub-list">
                                         {genre.subgenres.map((s) => (
                                             <li key={s.id} className="sub-item">
@@ -80,6 +205,33 @@ export default function GenresContent() {
                                 )}
                             </div>
                         </div>
+
+                        {editingId !== genre.id && user?.hasDeletionPermission && (
+                            <button
+                                className="btn-edit"
+                                style={{ marginLeft: 'auto', marginRight: '0.5rem' }}
+                                onClick={() => setConfirmDeleteId(genre.id)}
+                                title="Löschen"
+                            >
+                                🗑
+                            </button>
+                        )}
+
+                        {confirmDeleteId === genre.id && user?.hasDeletionPermission && (
+                            <div className="modal-overlay">
+                                <div className="modal-box">
+                                    <p>Möchtest du dieses Genre wirklich löschen?</p>
+                                    <div className="modal-actions">
+                                        <button className="btn btn-confirm" onClick={() => handleDelete(genre.id)}>
+                                            Ja, löschen
+                                        </button>
+                                        <button className="btn btn-cancel" onClick={() => setConfirmDeleteId(null)}>
+                                            Abbrechen
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
                     </div>
                 ))}
             </div>


### PR DESCRIPTION
## Summary
- implement CRUD endpoints for genres and countries with nested items
- extend `countries-with-cities` to return ISO codes
- add editing UI for countries and their cities
- add editing UI for genres and their subgenres

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862765eb09c8330907d4eb4172e8eb0