### PR TITLE
Fix profile sidebar scroll offset

### DIFF
--- a/eventim-disability-integration/src/pages/profile/index.jsx
+++ b/eventim-disability-integration/src/pages/profile/index.jsx
@@ -95,7 +95,9 @@ export default function ProfilePage() {
 
     const scrollTo = ref => {
         if (ref?.current) {
-            ref.current.scrollIntoView({ behavior: "smooth", block: "start" });
+            const offset = window.innerHeight * 0.11;
+            const y = ref.current.getBoundingClientRect().top + window.pageYOffset - offset;
+            window.scrollTo({ top: y, behavior: "smooth" });
         }
     };
 


### PR DESCRIPTION
## Summary
- adjust sidebar scroll behavior on Profile page to account for fixed navbar height

## Testing
- `npm test --silent -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686281bc21848330a5366f8b67bcd5fd