### PR TITLE
Fix profile sidebar scrolling

### DIFF
--- a/eventim-disability-integration/src/pages/profile/index.jsx
+++ b/eventim-disability-integration/src/pages/profile/index.jsx
@@ -92,12 +92,16 @@ export default function ProfilePage() {
     const ordersRef = useRef(null);
     const personalDataRef = useRef(null);
     const faqRef    = useRef(null);
+    const mainContentRef = useRef(null);
 
     const scrollTo = ref => {
-        if (ref?.current) {
+        if (ref?.current && mainContentRef.current) {
+            const container = mainContentRef.current;
             const offset = window.innerHeight * 0.11;
-            const y = ref.current.getBoundingClientRect().top + window.pageYOffset - offset;
-            window.scrollTo({ top: y, behavior: "smooth" });
+            const rect = ref.current.getBoundingClientRect();
+            const containerRect = container.getBoundingClientRect();
+            const y = container.scrollTop + rect.top - containerRect.top - offset;
+            container.scrollTo({ top: y, behavior: "smooth" });
         }
     };
 
@@ -401,7 +405,7 @@ export default function ProfilePage() {
             </aside>
 
             {/* Main Content */}
-            <main className="main-content">
+            <main className="main-content" ref={mainContentRef}>
                 <div className="inner-container">
 
                     {/* „Meine Events“ */}
@@ -818,3 +822,4 @@ export default function ProfilePage() {
         </div>
 );
 }
+

--- a/eventim-disability-integration/src/styles/profile.css
+++ b/eventim-disability-integration/src/styles/profile.css
@@ -9,7 +9,7 @@
     /* fill the viewport and hide extra overflow */
     height: 100vh;
     font-family: Arial, sans-serif;
-    overflow-y: auto;
+    overflow-y: hidden; /* scrolling handled inside main-content */
     overflow-x: hidden;
 }
 
@@ -94,7 +94,10 @@
     box-sizing: border-box;
     flex: 1 1 auto;
     width: auto;
-    scroll-padding-top: 7vh;
+    height: 100%;
+    overflow-y: auto;   /* allow internal scrolling */
+    scroll-padding-top: 11vh;
+    padding-bottom: 12vh; /* space for footer when scrolled to last section */
 }
 
 .inner-container {
@@ -447,6 +450,7 @@
 @media (max-width: 768px) {
     .profile-container {
         flex-direction: column;
+        overflow-y: auto; /* allow full page scrolling on small screens */
     }
 
     .sidebar {
@@ -458,6 +462,8 @@
     .main-content {
         width: 100%;
         padding: 1rem;
+        height: auto;
+        overflow-y: visible;
     }
 }
 


### PR DESCRIPTION
## Summary
- allow main content to handle scrolling so sidebar stays put
- add bottom space so last section can scroll with offset

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862857509388330a772692b1f9fca45