### PR TITLE
Display disability request status

### DIFF
--- a/eventim-disability-integration/src/pages/profile/index.jsx
+++ b/eventim-disability-integration/src/pages/profile/index.jsx
@@ -725,7 +725,15 @@ export default function ProfilePage() {
                                 <p className="subtitle">Wenn du einen Schwerbehindertenausweis besitzt und einen Nachteilsausgleich benötigst, kannst du diesen hier beantragen.</p>
                             <div className="content-inner">
                                 {user?.requestForDisability ? (
-                                    <div className="no-orders" style={{color: "#28a745", backgroundColor: "#e6f4ea"}}>Sie sind bereits für den Nachteilsausgleich registriert.</div>
+                                    user?.isCurrentlyDisabled ? (
+                                        <div className="no-orders" style={{color: "#28a745", backgroundColor: "#e6f4ea"}}>
+                                            Dein Nachteilsausgleich wurde genehmigt, du hast die Möglichkeit, auf deine Bedürfnisse abgestimmte Events zu buchen
+                                        </div>
+                                    ) : (
+                                        <div className="no-orders" style={{color: "#856404", backgroundColor: "#fff3cd"}}>
+                                            Dein Antrag ist eingetroffen und wird von einem unserer Servicemitarbeiter bearbeitet.
+                                        </div>
+                                    )
                                 ) : (
                                     <>
                                         {showDisabilityForm ? (


### PR DESCRIPTION
## Summary
- show specific messaging on profile page depending on disability request status

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c274bbbc8330a71bdea25c67e653