### PR TITLE
Add timeout fallback to 404 page

### DIFF
--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { API_BASE_URL } from '../../../../../config';
 import { useAuth } from '../../../../../hooks/useAuth';
 import { useCart } from "../../../../../hooks/useCart";
+import Custom404 from '../../../../../404';
 
 export default function EventPage() {
     const router = useRouter();
@@ -19,6 +20,7 @@ export default function EventPage() {
     const [qty, setQty] = useState(1);
     const [qty_disabled, setQty_disabled] = useState(1);
     const [selectedCat, setSelectedCat] = useState(null);
+    const [show404, setShow404] = useState(false);
 
     // Track category IDs already in cart
     const [inCartItems, setInCartItems] = useState({});
@@ -81,6 +83,15 @@ export default function EventPage() {
         };
         load();
     }, [artist, tour, event]);
+
+    useEffect(() => {
+        if (!artist || !tour || !event) return;
+        setShow404(false);
+        const timer = setTimeout(() => {
+            if (!eventData) setShow404(true);
+        }, 3000);
+        return () => clearTimeout(timer);
+    }, [artist, tour, event, eventData]);
 
     const userMarks = (user && user.disabilityMarks) || [];
     const notExpired = user?.disabilityCardExpiryDate && new Date(user.disabilityCardExpiryDate) >= new Date();
@@ -267,6 +278,7 @@ export default function EventPage() {
     };
 
 
+    if (show404) return <Custom404 />;
     if (loading) return <div>Loading …</div>;
     if (error) return <div>{error}</div>;
     if (!eventData) return <div>Event nicht gefunden</div>;

--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/index.jsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { API_BASE_URL } from '../../../../config';
 import FilterBar from "../../../../components/filter-bar";
 import { useAuth } from '../../../../hooks/useAuth';
+import Custom404 from '../../../../404';
 
 export default function TourEventsPage() {
     const router = useRouter();
@@ -13,6 +14,7 @@ export default function TourEventsPage() {
     const [tourData, setTourData] = useState(null);
     const [events, setEvents] = useState([]);
     const [availability, setAvailability] = useState({});
+    const [show404, setShow404] = useState(false);
 
     useEffect(() => {
         if (!tour) return;
@@ -34,6 +36,15 @@ export default function TourEventsPage() {
     }, [tour]);
 
     useEffect(() => {
+        if (!tour) return;
+        setShow404(false);
+        const timer = setTimeout(() => {
+            if (!tourData) setShow404(true);
+        }, 3000);
+        return () => clearTimeout(timer);
+    }, [tour, tourData]);
+
+    useEffect(() => {
         if (events.length === 0) return;
         const fetchCaps = async () => {
             const map = {};
@@ -50,6 +61,7 @@ export default function TourEventsPage() {
         fetchCaps();
     }, [events]);
 
+    if (show404) return <Custom404 />;
     if (!tourData) return <div>Loading …</div>;
 
     const formatDate = (d) =>

--- a/eventim-disability-integration/src/pages/artists/[artist]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/index.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import FilterBar from '../../../components/filter-bar';
 import { API_BASE_URL } from '../../../config';
+import Custom404 from '../../../404';
 
 export default function ArtistPage() {
     const router = useRouter();
@@ -11,6 +12,7 @@ export default function ArtistPage() {
     const [tours, setTours] = useState([]);
     const [basicFilteredTours, setBasicFilteredTours] = useState([]);
     const [filteredTours, setFilteredTours] = useState([]);
+    const [show404, setShow404] = useState(false);
 
     const [filterStartDate, setFilterStartDate] = useState('');
     const [filterEndDate, setFilterEndDate] = useState('');
@@ -41,6 +43,15 @@ export default function ArtistPage() {
         };
         loadArtist();
     }, [artist]);
+
+    useEffect(() => {
+        if (!artist) return;
+        setShow404(false);
+        const timer = setTimeout(() => {
+            if (!artistData) setShow404(true);
+        }, 3000);
+        return () => clearTimeout(timer);
+    }, [artist, artistData]);
 
     useEffect(() => {
         const fetchTours = async () => {
@@ -137,6 +148,7 @@ export default function ArtistPage() {
         setFilterArtistsInternal(copy);
     };
 
+    if (show404) return <Custom404 />;
     if (!artistData) return <div>Loading …</div>;
 
     const artistImage = artistData.artist_image


### PR DESCRIPTION
## Summary
- show `Custom404` component when artist, tour, or event fails to load in time
- import `Custom404` in dynamic pages
- trigger 404 after 3s if data is still missing

## Testing
- `npm install` *(passed)*
- `CI=true npm test` *(failed: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686648ea8da4833098665ecfb12d49c7