### PR TITLE
Handle missing event data with 404 redirect

### DIFF
--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
@@ -30,6 +30,15 @@ export default function EventPage() {
     const [addDisabled, setAddDisabled] = useState(false);
     const [assistanceInCart, setAssistanceInCart] = useState(false);
 
+    // Redirect to 404 page if event data could not be loaded within 3 seconds
+    useEffect(() => {
+        if (!artist || !tour || !event) return;
+        const timer = setTimeout(() => {
+            if (!eventData) router.replace('/404');
+        }, 3000);
+        return () => clearTimeout(timer);
+    }, [artist, tour, event, eventData]);
+
     // Build lookup table for items currently in cart
     useEffect(() => {
         if (!loggedIn) {

--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/index.jsx
@@ -14,6 +14,15 @@ export default function TourEventsPage() {
     const [events, setEvents] = useState([]);
     const [availability, setAvailability] = useState({});
 
+    // Redirect to 404 page if tour data could not be loaded within 3 seconds
+    useEffect(() => {
+        if (!artist || !tour) return;
+        const timer = setTimeout(() => {
+            if (!tourData) router.replace('/404');
+        }, 3000);
+        return () => clearTimeout(timer);
+    }, [artist, tour, tourData]);
+
     useEffect(() => {
         if (!tour) return;
         const load = async () => {

--- a/eventim-disability-integration/src/pages/artists/[artist]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/index.jsx
@@ -19,6 +19,15 @@ export default function ArtistPage() {
     const [filterCity, setFilterCity] = useState('');
     const [filterArtists, setFilterArtistsInternal] = useState([]);
 
+    // Redirect to 404 page if artist data could not be loaded within 3 seconds
+    useEffect(() => {
+        if (!artist) return;
+        const timer = setTimeout(() => {
+            if (!artistData) router.replace('/404');
+        }, 3000);
+        return () => clearTimeout(timer);
+    }, [artist, artistData]);
+
     const filterFields = [
         { key: 'title', label: 'Titel', match: 'startsWith' },
         { key: 'subtitle', label: 'Subtitle', match: 'contains' },


### PR DESCRIPTION
## Summary
- redirect to `404.jsx` if artist data isn't fetched within three seconds
- redirect to `404.jsx` if tour data isn't fetched within three seconds
- redirect to `404.jsx` if event data isn't fetched within three seconds

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686648ea8da4833098665ecfb12d49c7