### PR TITLE
Improve homepage scroller smoothness

### DIFF
--- a/eventim-disability-integration/src/components/ImageScroller.jsx
+++ b/eventim-disability-integration/src/components/ImageScroller.jsx
@@ -5,11 +5,12 @@ import React, { useState, useEffect } from "react";
 
 const ImageScroller = ({ tour }) => {
     // `tour` ist ein Array von { imageId, title, link }
-    // Verdoppeln für Endlosschleife
-    const loopedTours = [...tour, ...tour, ...tour, ...tour, ...tour, ...tour, ...tour];
+    // Nur zweimal fuer Endlosschleife noetig
+    const loopedTours = [...tour, ...tour];
 
     // Hier speichern wir die gemappten Object-URLs
     const [urls, setUrls] = useState({}); // { [imageId]: objectURL }
+    const [ready, setReady] = useState(false);
 
     useEffect(() => {
         let isMounted = true;
@@ -31,7 +32,9 @@ const ImageScroller = ({ tour }) => {
             }
         }
 
-        fetchAll();
+        fetchAll().then(() => {
+            if (isMounted) setReady(true);
+        });
         return () => {
             isMounted = false;
             // Cleanup: revoke all object URLs
@@ -41,7 +44,13 @@ const ImageScroller = ({ tour }) => {
 
     return (
         <div className="homepage-scroller-container">
-            <div className="homepage-scroller">
+            <div
+                className="homepage-scroller"
+                style={{
+                    "--scroll-duration": `${tour.length * 5}s`,
+                    animationPlayState: ready ? "running" : "paused",
+                }}
+            >
                 {loopedTours.map((t, idx) => {
                     const imgUrl = urls[t.imageId] || null;
                     return (

--- a/eventim-disability-integration/src/styles/scroller.css
+++ b/eventim-disability-integration/src/styles/scroller.css
@@ -1,17 +1,22 @@
+
 .homepage-scroller-container {
     width: 100%;
-    overflow: visible;
+    overflow: hidden;
     position: relative;
 }
 
 .homepage-scroller {
     display: flex;
-    animation: scroll 40s linear infinite;
+    gap: 16px;
+    width: max-content;
+    animation: scroll var(--scroll-duration, 40s) linear infinite;
 }
 
-.homepage-scroller-img {
-    width: auto;
+.homepage-scroller-img,
+.homepage-scroller-img-placeholder {
+    width: 250px;
     height: 250px;
+    flex-shrink: 0;
     transition: transform 0.3s ease-in-out;
     overflow: hidden;
     display: flex;
@@ -22,15 +27,19 @@
     object-position: center;
 }
 
+.homepage-scroller-img-placeholder {
+    background-color: #f5f5f5;
+}
+
 .homepage-scroller-img:hover {
     transform: scale(1.1);
 }
 
 @keyframes scroll {
-    0% {
+    from {
         transform: translateX(0);
     }
-    100% {
+    to {
         transform: translateX(-50%);
     }
 }


### PR DESCRIPTION
## Summary
- update `ImageScroller` to wait for loaded images before running animation
- style scroller for hidden overflow and repeat items only twice
- give images fixed size and placeholder styling for seamless scroll

## Testing
- `npm test` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68664c4e2438833081fa6711f42ac8fc