### PR TITLE
Enable venue image editing

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -1488,10 +1488,19 @@ app.get('/venues-detailed', async (req, res) => {
     }
 });
 
-// PUT: Update a venue and its areas
-app.put('/venues/:id', async (req, res) => {
+// PUT: Update a venue, its areas and optionally the image
+app.put('/venues/:id', upload.single('venue_image'), async (req, res) => {
     const venueId = req.params.id;
-    const { name, address, cityId, website, venueAreas = [] } = req.body;
+    const { name, address, cityId, website } = req.body;
+    let venueAreas = [];
+    try {
+        venueAreas = req.body.venueAreas
+            ? JSON.parse(req.body.venueAreas)
+            : [];
+        if (!Array.isArray(venueAreas)) venueAreas = [];
+    } catch {
+        venueAreas = [];
+    }
 
     if (!name?.trim() || !address?.trim() || !cityId) {
         return res
@@ -1501,6 +1510,17 @@ app.put('/venues/:id', async (req, res) => {
 
     try {
         await client.query('BEGIN');
+
+        // Aktuelles Bild ermitteln
+        const { rows: existingVenue } = await client.query(
+            'SELECT venue_image FROM venues WHERE id = $1',
+            [venueId]
+        );
+        if (existingVenue.length === 0) {
+            await client.query('ROLLBACK');
+            return res.status(404).json({ message: 'Venue nicht gefunden' });
+        }
+        const oldImageId = existingVenue[0].venue_image;
 
         await client.query(
             `UPDATE venues
@@ -1512,6 +1532,18 @@ app.put('/venues/:id', async (req, res) => {
                WHERE id = $5`,
             [name.trim(), address.trim(), cityId, website || null, venueId]
         );
+
+        if (req.file) {
+            const newImageId = uuidv4();
+            await client.query(
+                'INSERT INTO images (id, image_data, image_type, entity_type, entity_id) VALUES ($1,$2,$3,$4,$5)',
+                [newImageId, req.file.buffer, req.file.mimetype, 'venue', venueId]
+            );
+            await client.query('UPDATE venues SET venue_image = $1 WHERE id = $2', [newImageId, venueId]);
+            if (oldImageId) {
+                await client.query('DELETE FROM images WHERE id = $1', [oldImageId]);
+            }
+        }
 
         // Bestehende Areas laden
         const { rows: existing } = await client.query(

--- a/eventim-disability-integration/src/pages/admin/venues/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/index.jsx
@@ -13,6 +13,8 @@ export default function VenuesContent() {
         address: '',
         cityId: '',
         website: '',
+        venue_image: null,
+        existingImageId: null,
     });
     const [cities, setCities] = useState([]);
     const [areas, setAreas] = useState([]);
@@ -77,6 +79,8 @@ export default function VenuesContent() {
             address: venue.address || '',
             cityId: venue.cityId || '',
             website: venue.website || '',
+            venue_image: null,
+            existingImageId: venue.venue_image || null,
         });
         try {
             const res = await fetch(`http://localhost:4000/venue-areas?venueId=${venue.id}`);
@@ -90,8 +94,12 @@ export default function VenuesContent() {
     };
 
     const handleInputChange = (e) => {
-        const { name, value } = e.target;
-        setEditedData((prev) => ({ ...prev, [name]: value }));
+        const { name, value, files } = e.target;
+        if (files) {
+            setEditedData((prev) => ({ ...prev, [name]: files[0] }));
+        } else {
+            setEditedData((prev) => ({ ...prev, [name]: value }));
+        }
     };
 
     const addArea = () => {
@@ -110,17 +118,19 @@ export default function VenuesContent() {
 
     const handleSave = async () => {
         try {
-            const payload = {
-                name: editedData.name,
-                address: editedData.address,
-                cityId: editedData.cityId,
-                website: editedData.website,
-                venueAreas,
-            };
+            const fd = new FormData();
+            fd.append('name', editedData.name);
+            fd.append('address', editedData.address);
+            fd.append('cityId', editedData.cityId);
+            fd.append('website', editedData.website);
+            fd.append('venueAreas', JSON.stringify(venueAreas));
+            if (editedData.venue_image instanceof File) {
+                fd.append('venue_image', editedData.venue_image);
+            }
+
             const response = await fetch(`http://localhost:4000/venues/${editedData.id}`, {
                 method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload),
+                body: fd,
             });
             if (!response.ok) throw new Error('Server-Fehler beim Speichern');
             setEditingId(null);
@@ -225,6 +235,20 @@ export default function VenuesContent() {
                         </div>
 
                         <div className="card-body">
+                            <div className="image-wrapper">
+                                <img
+                                    className="artist-image"
+                                    src={
+                                        editingId === venue.id &&
+                                        editedData.venue_image instanceof File
+                                            ? URL.createObjectURL(editedData.venue_image)
+                                            : venue.venue_image
+                                                ? `http://localhost:4000/image/${venue.venue_image}`
+                                                : '/pictures/placeholder.png'
+                                    }
+                                    alt={venue.name || 'Unbekanntes Venue'}
+                                />
+                            </div>
                             <div className="details-wrapper">
                                 {editingId === venue.id ? (
                                     <>
@@ -256,6 +280,13 @@ export default function VenuesContent() {
                                             onChange={handleInputChange}
                                             placeholder="Website"
                                             className="input-website"
+                                        />
+                                        <input
+                                            type="file"
+                                            name="venue_image"
+                                            onChange={handleInputChange}
+                                            accept="image/*"
+                                            className="input-file"
                                         />
 
                                         <div style={{ marginBottom: '0.5rem' }}>


### PR DESCRIPTION
## Summary
- allow uploading new venue images during edits
- show venue images on the admin venues overview page
- support venue image updates on the backend

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666da3f5bc8330a8ec0a972cb83bc3