### PR TITLE
Restrict admin pages to full admin rights

### DIFF
--- a/eventim-disability-integration/src/adminPermissions.js
+++ b/eventim-disability-integration/src/adminPermissions.js
@@ -1,0 +1,8 @@
+export const ADMIN_PERMISSIONS = [
+    'hasRoleAppointingCapability',
+    'hasDisabilityApprovalAccess',
+    'hasAccountManagementAccess',
+    'hasCreationAccess',
+    'hasEditingAccess',
+    'hasDeletionPermission',
+];

--- a/eventim-disability-integration/src/pages/admin/artists/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/artists/create.jsx
@@ -2,9 +2,10 @@ import React, { useState, useEffect } from 'react';
 import { useValidation } from '../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
 
 export default function ArtistCreation() {
-    useRequireAccess(['hasCreationAccess']);
+    useRequireAccess(ADMIN_PERMISSIONS);
     const router = useRouter();
     const [formData, setFormData] = useState({
         name: '',

--- a/eventim-disability-integration/src/pages/admin/artists/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/artists/index.jsx
@@ -2,8 +2,11 @@ import React, { useEffect, useState } from 'react';
 import FilterBar from '../../../components/filter-bar';
 import { useRouter } from 'next/router';
 import { useAuth } from '../../../hooks/useAuth';
+import { useRequireAccess } from '../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
 
 export default function ArtistsContent() {
+    useRequireAccess(ADMIN_PERMISSIONS);
     const [artists, setArtists] = useState([]);
     const [filteredArtists, setFilteredArtists] = useState([]);
     const [editingId, setEditingId] = useState(null);

--- a/eventim-disability-integration/src/pages/admin/countries/cities/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/cities/create.jsx
@@ -2,9 +2,10 @@ import React, { useState, useEffect } from 'react';
 import { useValidation } from '../../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../../adminPermissions';
 
 export default function CityCreation() {
-    useRequireAccess(['hasCreationAccess']);
+    useRequireAccess(ADMIN_PERMISSIONS);
     const router = useRouter();
     const [formData, setFormData] = useState({
         name: '',

--- a/eventim-disability-integration/src/pages/admin/countries/cities/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/cities/index.jsx
@@ -1,3 +1,6 @@
+import { useRequireAccess } from '../../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../../adminPermissions';
+
 export async function getServerSideProps(context) {
     return {
         redirect: {
@@ -8,5 +11,6 @@ export async function getServerSideProps(context) {
 }
 
 export default function Index() {
+    useRequireAccess(ADMIN_PERMISSIONS);
     return null;
 }

--- a/eventim-disability-integration/src/pages/admin/countries/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/create.jsx
@@ -3,9 +3,10 @@ import React, { useState } from 'react';
 import { useValidation } from '../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
 
 export default function CountryCreation() {
-    useRequireAccess(['hasCreationAccess']);
+    useRequireAccess(ADMIN_PERMISSIONS);
     const router = useRouter();
     const [formData, setFormData] = useState({ name: '', code: '' });
     const [message, setMessage] = useState('');

--- a/eventim-disability-integration/src/pages/admin/countries/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/index.jsx
@@ -3,8 +3,11 @@ import FilterBar from '../../../components/filter-bar';
 import { useRouter } from 'next/router';
 import { API_BASE_URL } from '../../../config';
 import { useAuth } from '../../../hooks/useAuth';
+import { useRequireAccess } from '../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
 
 export default function CountriesContent() {
+    useRequireAccess(ADMIN_PERMISSIONS);
     const [countries, setCountries] = useState([]);
     const [filteredCountries, setFilteredCountries] = useState([]);
     const [editingId, setEditingId] = useState(null);

--- a/eventim-disability-integration/src/pages/admin/genres/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/genres/create.jsx
@@ -3,9 +3,10 @@ import React, { useState } from 'react';
 import { useValidation } from '../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
 
 export default function GenreCreation() {
-    useRequireAccess(['hasCreationAccess']);
+    useRequireAccess(ADMIN_PERMISSIONS);
     const router = useRouter();
     const [formData, setFormData] = useState({
         name: '',

--- a/eventim-disability-integration/src/pages/admin/genres/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/genres/index.jsx
@@ -3,8 +3,11 @@ import FilterBar from '../../../components/filter-bar';
 import { useRouter } from 'next/router';
 import { API_BASE_URL } from '../../../config';
 import { useAuth } from '../../../hooks/useAuth';
+import { useRequireAccess } from '../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
 
 export default function GenresContent() {
+    useRequireAccess(ADMIN_PERMISSIONS);
     const [genres, setGenres] = useState([]);
     const [filteredGenres, setFilteredGenres] = useState([]);
     const [editingId, setEditingId] = useState(null);

--- a/eventim-disability-integration/src/pages/admin/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/index.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
+import { useRequireAccess } from '../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../adminPermissions';
 
 export default function AdminHome() {
+    useRequireAccess(ADMIN_PERMISSIONS);
     const entities = [
         { name: 'Artists', url: '/admin/artists' },
         { name: 'Countries', url: '/admin/countries' },

--- a/eventim-disability-integration/src/pages/admin/tours/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/create.jsx
@@ -4,9 +4,10 @@
 import React, { useState, useEffect } from "react";
 import { useValidation } from '../../../hooks/useValidation';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
 
 export default function TourCreation() {
-    useRequireAccess(['hasCreationAccess']);
+    useRequireAccess(ADMIN_PERMISSIONS);
     // --------------------------------------------------
     // 1) State
     // --------------------------------------------------

--- a/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
@@ -4,9 +4,10 @@ import React, { useState, useEffect } from 'react';
 import { useValidation } from '../../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../../adminPermissions';
 
 export default function EventCreation() {
-    useRequireAccess(['hasCreationAccess']);
+    useRequireAccess(ADMIN_PERMISSIONS);
     const router = useRouter();
     const [formData, setFormData] = useState({
         tourId: '',

--- a/eventim-disability-integration/src/pages/admin/tours/events/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/events/index.jsx
@@ -1,3 +1,6 @@
+import { useRequireAccess } from '../../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../../adminPermissions';
+
 export async function getServerSideProps(context) {
     return {
         redirect: {
@@ -8,5 +11,6 @@ export async function getServerSideProps(context) {
 }
 
 export default function Index() {
+    useRequireAccess(ADMIN_PERMISSIONS);
     return null;
 }

--- a/eventim-disability-integration/src/pages/admin/tours/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/index.jsx
@@ -5,8 +5,11 @@ import FilterBar from '../../../components/filter-bar';
 import { useRouter } from 'next/router';
 import { API_BASE_URL } from '../../../config';
 import { useAuth } from '../../../hooks/useAuth';
+import { useRequireAccess } from '../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
 
 export default function ToursContent() {
+    useRequireAccess(ADMIN_PERMISSIONS);
     const [tours, setTours] = useState([]);
     const [basicFilteredTours, setBasicFilteredTours] = useState([]);
     const [filteredTours, setFilteredTours] = useState([]);

--- a/eventim-disability-integration/src/pages/admin/venues/areas/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/areas/create.jsx
@@ -3,9 +3,10 @@
 import React, { useState } from 'react';
 import { useValidation } from '../../../../hooks/useValidation';
 import { useRequireAccess } from '../../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../../adminPermissions';
 
 export default function AreaCreation() {
-    useRequireAccess(['hasCreationAccess']);
+    useRequireAccess(ADMIN_PERMISSIONS);
     const [formData, setFormData] = useState({
         name: '',
         description: ''

--- a/eventim-disability-integration/src/pages/admin/venues/areas/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/areas/index.jsx
@@ -1,3 +1,6 @@
+import { useRequireAccess } from '../../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../../adminPermissions';
+
 export async function getServerSideProps(context) {
     return {
         redirect: {
@@ -8,5 +11,6 @@ export async function getServerSideProps(context) {
 }
 
 export default function Index() {
+    useRequireAccess(ADMIN_PERMISSIONS);
     return null;
 }

--- a/eventim-disability-integration/src/pages/admin/venues/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/create.jsx
@@ -3,9 +3,10 @@ import React, { useState, useEffect } from 'react';
 import { useValidation } from '../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
 
 export default function VenueCreation() {
-    useRequireAccess(['hasCreationAccess']);
+    useRequireAccess(ADMIN_PERMISSIONS);
     const router = useRouter();
     const [formData, setFormData] = useState({
         name: '',

--- a/eventim-disability-integration/src/pages/admin/venues/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/index.jsx
@@ -2,8 +2,11 @@ import React, { useEffect, useState } from 'react';
 import FilterBar from '../../../components/filter-bar';
 import { useRouter } from 'next/router';
 import { useAuth } from '../../../hooks/useAuth';
+import { useRequireAccess } from '../../../hooks/useRequireAccess';
+import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
 
 export default function VenuesContent() {
+    useRequireAccess(ADMIN_PERMISSIONS);
     const [venues, setVenues] = useState([]);
     const [filteredVenues, setFilteredVenues] = useState([]);
     const [editingId, setEditingId] = useState(null);


### PR DESCRIPTION
## Summary
- add a shared `ADMIN_PERMISSIONS` constant
- guard all admin pages using `useRequireAccess`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_686697573640833099bd9867574a755a