### PR TITLE
Enable editing events within tour editor

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -3087,6 +3087,31 @@ app.get('/event-capacities/:id', async (req, res) => {
     }
 });
 
+// PUT /events/:id – aktualisiert die Basisdaten eines Events
+app.put('/events/:id', async (req, res) => {
+    const eventId = req.params.id;
+    const { venueId, doorTime, startTime, endTime, description } = req.body;
+
+    try {
+        await client.query(
+            `UPDATE events
+                 SET venue_id   = $1,
+                     door_time  = $2,
+                     start_time = $3,
+                     end_time   = $4,
+                     description = $5,
+                     updated_at = NOW()
+               WHERE id = $6`,
+            [venueId || null, doorTime || null, startTime || null, endTime || null, description || null, eventId]
+        );
+
+        return res.status(200).json({ message: 'Event aktualisiert' });
+    } catch (err) {
+        console.error('Update-event error:', err);
+        return res.status(500).json({ message: 'Serverfehler beim Aktualisieren des Events' });
+    }
+});
+
 // DELETE /events/:id – entfernt ein Event, sofern keine Tickets existieren
 app.delete('/events/:id', async (req, res) => {
     const eventId = req.params.id;

--- a/eventim-disability-integration/src/pages/admin/tours/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/index.jsx
@@ -27,6 +27,8 @@ export default function ToursContent() {
     const [allGenres, setAllGenres] = useState([]);
     const [tourArtists, setTourArtists] = useState([]);
     const [tourGenres, setTourGenres] = useState([]);
+    const [allVenues, setAllVenues] = useState([]);
+    const [eventEdits, setEventEdits] = useState({});
     const [confirmDeleteId, setConfirmDeleteId] = useState(null);
     const [eventTickets, setEventTickets] = useState({});
 
@@ -78,6 +80,7 @@ export default function ToursContent() {
         fetchTours();
         fetchAllArtists();
         fetchAllGenresWithSub();
+        fetchAllVenues();
     }, []);
     const fetchTours = async () => {
         try {
@@ -115,6 +118,17 @@ export default function ToursContent() {
             setAllGenres(j.genres || []);
         } catch {
             setAllGenres([]);
+        }
+    };
+
+    const fetchAllVenues = async () => {
+        try {
+            const res = await fetch(`${API_BASE_URL}/venues`);
+            if (!res.ok) throw new Error();
+            const j = await res.json();
+            setAllVenues(j.venues || []);
+        } catch {
+            setAllVenues([]);
         }
     };
 
@@ -208,11 +222,43 @@ export default function ToursContent() {
         } catch {
             setTourArtists([]); setTourGenres([]);
         }
+
+        // Event-Details laden
+        try {
+            const promises = (tour.events || []).map((ev) =>
+                fetch(`${API_BASE_URL}/event-details/${ev.id}`).then((r) =>
+                    r.ok ? r.json() : null
+                )
+            );
+            const arr = await Promise.all(promises);
+            const map = {};
+            arr.forEach((d) => {
+                if (d && d.event) {
+                    map[d.event.id] = {
+                        venueId: d.event.venue_id || '',
+                        doorTime: d.event.door_time ? d.event.door_time.slice(0, 16) : '',
+                        startTime: d.event.start_time ? d.event.start_time.slice(0, 16) : '',
+                        endTime: d.event.end_time ? d.event.end_time.slice(0, 16) : '',
+                        description: d.event.description || ''
+                    };
+                }
+            });
+            setEventEdits(map);
+        } catch {
+            setEventEdits({});
+        }
     };
     const handleInputChange = (e) => {
         const { name, value, files } = e.target;
         if (files) setEditedData((p) => ({ ...p, [name]: files[0] }));
         else setEditedData((p) => ({ ...p, [name]: value }));
+    };
+
+    const handleEventFieldChange = (eventId, field, value) => {
+        setEventEdits((prev) => ({
+            ...prev,
+            [eventId]: { ...prev[eventId], [field]: value }
+        }));
     };
     const addArtistField = () => setTourArtists((p) => [...p, { id: '', name: '' }]);
     const updateArtistField = (i, id) => {
@@ -268,6 +314,15 @@ export default function ToursContent() {
                 body: fd,
             });
             if (!r.ok) throw new Error();
+
+            const eventPromises = Object.entries(eventEdits).map(([eid, data]) =>
+                fetch(`${API_BASE_URL}/events/${eid}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(data)
+                })
+            );
+            await Promise.all(eventPromises);
             setEditingId(null);
             fetchTours();
         } catch {
@@ -576,6 +631,63 @@ export default function ToursContent() {
                                                     + Event hinzufügen
                                                 </button>
                                             </div>
+
+                                            {(tour.events || []).map((ev, idx) => {
+                                                const d = eventEdits[ev.id] || {};
+                                                return (
+                                                    <div key={ev.id} className="section-block event-edit-block">
+                                                        <span className="section-label">Event {idx + 1}</span>
+                                                        <label className="event-edit-label">
+                                                            Venue:
+                                                            <select
+                                                                value={d.venueId || ''}
+                                                                onChange={(e) => handleEventFieldChange(ev.id, 'venueId', e.target.value)}
+                                                                className="input-website"
+                                                            >
+                                                                <option value="">— Venue wählen —</option>
+                                                                {allVenues.map((v) => (
+                                                                    <option key={v.id} value={v.id}>
+                                                                        {v.name}
+                                                                    </option>
+                                                                ))}
+                                                            </select>
+                                                        </label>
+                                                        <label className="event-edit-label">
+                                                            Einlass:
+                                                            <input
+                                                                type="datetime-local"
+                                                                value={d.doorTime || ''}
+                                                                onChange={(e) => handleEventFieldChange(ev.id, 'doorTime', e.target.value)}
+                                                                className="input-date"
+                                                            />
+                                                        </label>
+                                                        <label className="event-edit-label">
+                                                            Start:
+                                                            <input
+                                                                type="datetime-local"
+                                                                value={d.startTime || ''}
+                                                                onChange={(e) => handleEventFieldChange(ev.id, 'startTime', e.target.value)}
+                                                                className="input-date"
+                                                            />
+                                                        </label>
+                                                        <label className="event-edit-label">
+                                                            Ende:
+                                                            <input
+                                                                type="datetime-local"
+                                                                value={d.endTime || ''}
+                                                                onChange={(e) => handleEventFieldChange(ev.id, 'endTime', e.target.value)}
+                                                                className="input-date"
+                                                            />
+                                                        </label>
+                                                        <textarea
+                                                            value={d.description || ''}
+                                                            onChange={(e) => handleEventFieldChange(ev.id, 'description', e.target.value)}
+                                                            className="input-website"
+                                                            placeholder="Beschreibung"
+                                                        />
+                                                    </div>
+                                                );
+                                            })}
                                         </>
                                     ) : (
                                         /* ——— DISPLAY MODE ——— */

--- a/eventim-disability-integration/src/styles/tours.css
+++ b/eventim-disability-integration/src/styles/tours.css
@@ -402,3 +402,17 @@
 }
 
 /* Modal and other styles remain as before… */
+
+/* Event edit block */
+.event-edit-block {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
+}
+.event-edit-label {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.9rem;
+    color: #333;
+}


### PR DESCRIPTION
## Summary
- add server endpoint to update events
- fetch venues and event details when editing a tour
- render editable event fields inside tour edit mode
- patch events along with the tour on save
- style event edit blocks

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867961124908330ace01477fd2489e4