### PR TITLE
Add unified back link to admin pages

### DIFF
--- a/eventim-disability-integration/src/components/back-link.jsx
+++ b/eventim-disability-integration/src/components/back-link.jsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { useRouter } from 'next/router';
+
+export default function BackLink() {
+    const router = useRouter();
+    return (
+        <div className="back-link-container">
+            <a onClick={() => router.back()} className="back-link">&larr; Zurück</a>
+        </div>
+    );
+}

--- a/eventim-disability-integration/src/pages/admin/artists/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/artists/create.jsx
@@ -5,6 +5,7 @@ import { useValidation } from '../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
+import BackLink from '../../components/back-link';
 
 export default function ArtistCreation() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -89,6 +90,7 @@ export default function ArtistCreation() {
 
     return (
         <div className="artist-container">
+            <BackLink />
             <h1>Neuen Künstler erstellen</h1>
 
             {message && (

--- a/eventim-disability-integration/src/pages/admin/artists/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/artists/index.jsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../../hooks/useAuth';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
+import BackLink from '../../components/back-link';
 
 export default function ArtistsContent() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -131,6 +132,7 @@ export default function ArtistsContent() {
 
     return (
         <div className="artists-wrapper">
+            <BackLink />
             <div className="artists-header">
                 <h2 className="artists-title">Übersicht – Künstler</h2>
                 {user?.hasCreationAccess && (

--- a/eventim-disability-integration/src/pages/admin/countries/cities/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/cities/create.jsx
@@ -3,6 +3,7 @@ import { useValidation } from '../../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../../hooks/useRequireAccess';
 import { ADMIN_PERMISSIONS } from '../../../../adminPermissions';
+import BackLink from '../../../components/back-link';
 
 export default function CityCreation() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -66,6 +67,7 @@ export default function CityCreation() {
 
     return (
         <div className="registration-container" style={{ maxWidth: '600px', margin: '0 auto', padding: '2rem' }}>
+            <BackLink />
             <h1 style={{ color: '#002b55', marginBottom: '1.5rem' }}>Neue Stadt anlegen</h1>
 
             {message && (

--- a/eventim-disability-integration/src/pages/admin/countries/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/create.jsx
@@ -3,6 +3,7 @@ import { useValidation } from '../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
+import BackLink from '../../components/back-link';
 
 export default function CountryCreation() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -62,6 +63,7 @@ export default function CountryCreation() {
 
     return (
         <div className="artist-container">
+            <BackLink />
             <h1>Neues Land anlegen</h1>
 
             {message && (

--- a/eventim-disability-integration/src/pages/admin/countries/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/index.jsx
@@ -4,6 +4,7 @@ import { API_BASE_URL } from '../../../config';
 import { useAuth } from '../../../hooks/useAuth';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
+import BackLink from '../../components/back-link';
 
 export default function CountriesContent() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -115,6 +116,7 @@ export default function CountriesContent() {
 
     return (
         <div className="artists-wrapper">
+            <BackLink />
             <div className="artists-header">
                 <h2 className="artists-title">Übersicht – Länder</h2>
                 {user?.hasCreationAccess && (

--- a/eventim-disability-integration/src/pages/admin/genres/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/genres/create.jsx
@@ -6,6 +6,7 @@ import { useValidation } from '../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
+import BackLink from '../../components/back-link';
 
 export default function GenreCreation() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -77,6 +78,7 @@ export default function GenreCreation() {
 
     return (
         <div className="artist-container">
+            <BackLink />
             <h1>Neues Genre erstellen</h1>
 
             {message && (

--- a/eventim-disability-integration/src/pages/admin/genres/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/genres/index.jsx
@@ -4,6 +4,7 @@ import { API_BASE_URL } from '../../../config';
 import { useAuth } from '../../../hooks/useAuth';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
+import BackLink from '../../components/back-link';
 
 export default function GenresContent() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -107,6 +108,7 @@ export default function GenresContent() {
 
     return (
         <div className="artists-wrapper">
+            <BackLink />
             <div className="artists-header">
                 <h2 className="artists-title">Übersicht – Genres</h2>
                 {user?.hasCreationAccess && (

--- a/eventim-disability-integration/src/pages/admin/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useRequireAccess } from '../../hooks/useRequireAccess';
 import { ADMIN_PERMISSIONS } from '../../adminPermissions';
+import BackLink from '../components/back-link';
 
 export default function AdminHome() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -17,6 +18,7 @@ export default function AdminHome() {
             <div className="content-inner" style={{ paddingTop: '24px' }}>
                 <div className="white-box events-white-box">
                     <div className="content-inner">
+                        <BackLink />
                         <h1 className="events-header" style={{color: "#002b55"}}>Admin Übersicht</h1>
                         <p className="subtitle">Übersicht aller ADMIN-Applikationen und Übersichten.</p>
                         <div className="profile-section-divider" />

--- a/eventim-disability-integration/src/pages/admin/tours/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/create.jsx
@@ -6,6 +6,7 @@ import { useValidation } from '../../../hooks/useValidation';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 import { useRouter } from 'next/navigation';
 import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
+import BackLink from '../../components/back-link';
 
 export default function TourCreation() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -174,6 +175,7 @@ export default function TourCreation() {
 
     return (
         <div className="artist-container">
+            <BackLink />
             <h1>Neue Tour erstellen</h1>
 
             {message && (

--- a/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
@@ -5,6 +5,7 @@ import { useValidation } from '../../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../../hooks/useRequireAccess';
 import { ADMIN_PERMISSIONS } from '../../../../adminPermissions';
+import BackLink from '../../../components/back-link';
 
 export default function EventCreation() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -329,6 +330,7 @@ export default function EventCreation() {
             className="registration-container"
             style={{ maxWidth: '600px', margin: '0 auto', padding: '2rem' }}
         >
+            <BackLink />
             <h1 style={{ color: '#002b55', marginBottom: '1.5rem' }}>Neues Event erstellen</h1>
 
             {message && (

--- a/eventim-disability-integration/src/pages/admin/tours/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/index.jsx
@@ -7,6 +7,7 @@ import { API_BASE_URL } from '../../../config';
 import { useAuth } from '../../../hooks/useAuth';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
+import BackLink from '../../components/back-link';
 
 export default function ToursContent() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -355,6 +356,7 @@ export default function ToursContent() {
 
     return (
         <div className="artists-wrapper">
+            <BackLink />
             {/* Header + Create */}
             <div className="artists-header">
                 <h2 className="artists-title">Übersicht – Touren</h2>

--- a/eventim-disability-integration/src/pages/admin/venues/areas/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/areas/create.jsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { useValidation } from '../../../../hooks/useValidation';
 import { useRequireAccess } from '../../../../hooks/useRequireAccess';
 import { ADMIN_PERMISSIONS } from '../../../../adminPermissions';
+import BackLink from '../../../components/back-link';
 
 export default function AreaCreation() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -56,6 +57,7 @@ export default function AreaCreation() {
 
     return (
         <div className="creation-container" style={{ maxWidth: '600px', margin: '0 auto', padding: '2rem' }}>
+            <BackLink />
             <h1 style={{ color: '#002b55', marginBottom: '1.5rem' }}>Neuen Bereich anlegen</h1>
 
             {message && (

--- a/eventim-disability-integration/src/pages/admin/venues/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/create.jsx
@@ -6,6 +6,7 @@ import { useValidation } from '../../../hooks/useValidation';
 import { useRouter } from 'next/router';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
+import BackLink from '../../components/back-link';
 
 export default function VenueCreation() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -125,6 +126,7 @@ export default function VenueCreation() {
 
     return (
         <div className="artist-container">
+            <BackLink />
             <h1>Neuen Veranstaltungsort anlegen</h1>
 
             {message && (

--- a/eventim-disability-integration/src/pages/admin/venues/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/index.jsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '../../../hooks/useAuth';
 import { useRequireAccess } from '../../../hooks/useRequireAccess';
 import { ADMIN_PERMISSIONS } from '../../../adminPermissions';
+import BackLink from '../../components/back-link';
 
 export default function VenuesContent() {
     useRequireAccess(ADMIN_PERMISSIONS);
@@ -158,6 +159,7 @@ export default function VenuesContent() {
 
     return (
         <div className="artists-wrapper">
+            <BackLink />
             <div className="artists-header">
                 <h2 className="artists-title">Übersicht – Venues</h2>
                 {user?.hasCreationAccess && (

--- a/eventim-disability-integration/src/styles/AdminTooling.css
+++ b/eventim-disability-integration/src/styles/AdminTooling.css
@@ -380,3 +380,9 @@
 .modal-actions button:last-child {
     background-color: #ccc;
 }
+
+/* Back Link */
+.back-link-container { margin: 0 10%; }
+.back-link { color: #007bff; cursor: pointer; text-decoration: none; display: inline-block; margin-bottom: 1rem; }
+.back-link:hover { text-decoration: underline; }
+


### PR DESCRIPTION
## Summary
- add reusable BackLink component
- add styling for back links
- include BackLink at the top of admin index and create pages

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ae6ad85c8330961caeb93a7ba83e