### PR TITLE
Enable profile editing for support in disability requests

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -1064,6 +1064,90 @@ app.patch('/users/:id', async (req, res) => {
     }
 });
 
+// PATCH: update user profile via service (Support-User)
+app.patch('/service/users/:id', async (req, res) => {
+    if (!req.session.userId) {
+        return res.status(401).json({ message: 'Not logged in' });
+    }
+    if (!req.session.hasAccountManagementAccess) {
+        return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    const paramUserId = req.params.id;
+    const {
+        salutation,
+        firstName,
+        lastName,
+        email,
+        company,
+        streetAddress,
+        postalCode,
+        city,
+        country,
+        birthDate,
+        phone,
+    } = req.body;
+
+    if (!firstName || !lastName || !email) {
+        return res.status(400).json({ message: 'firstName, lastName und email sind erforderlich' });
+    }
+
+    try {
+        const { rows } = await client.query(
+            `
+        UPDATE users
+           SET salutation     = $1,
+               first_name     = $2,
+               last_name      = $3,
+               email          = $4,
+               company        = $5,
+               street_address = $6,
+               postal_code    = $7,
+               city           = $8,
+               country        = $9,
+               birth_date     = $10,
+               phone          = $11,
+               updated_at     = NOW()
+         WHERE user_id = $12
+         RETURNING user_id,
+                   salutation     AS "salutation",
+                   first_name     AS "firstName",
+                   last_name      AS "lastName",
+                   email          AS "email",
+                   company        AS "company",
+                   street_address AS "streetAddress",
+                   postal_code    AS "postalCode",
+                   city           AS "city",
+                   country        AS "country",
+                   birth_date     AS "birthDate",
+                   phone          AS "phone"`,
+            [
+                salutation || null,
+                firstName.trim(),
+                lastName.trim(),
+                email.trim(),
+                company || null,
+                streetAddress || null,
+                postalCode || null,
+                city || null,
+                country || null,
+                birthDate || null,
+                phone || null,
+                paramUserId,
+            ]
+        );
+
+        if (rows.length === 0) {
+            return res.status(404).json({ message: 'User nicht gefunden' });
+        }
+
+        return res.status(200).json({ message: 'Profil aktualisiert', user: rows[0] });
+    } catch (err) {
+        console.error('Error updating profile (service):', err);
+        return res.status(500).json({ message: 'Serverfehler beim Aktualisieren des Profils' });
+    }
+});
+
 
 // Passwort eines Nutzers ändern
 app.patch('/users/:id/password', async (req, res) => {

--- a/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
+++ b/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
@@ -9,8 +9,43 @@ export default function DisabilityRequestModal({
     onClose,
     onAccept,
     onDecline,
+    canEdit = false,
+    onSave,
 }) {
     if (!user || !detail) return null;
+
+    const [editMode, setEditMode] = React.useState(false);
+    const [formData, setFormData] = React.useState({
+        salutation: user.salutation || '',
+        firstName: user.firstName || '',
+        lastName: user.lastName || '',
+        birthDate: user.birth_date || '',
+    });
+
+    React.useEffect(() => {
+        setFormData({
+            salutation: user.salutation || '',
+            firstName: user.firstName || '',
+            lastName: user.lastName || '',
+            birthDate: user.birth_date || '',
+        });
+    }, [user]);
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setFormData((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const handleSave = () => {
+        onSave &&
+            onSave({
+                salutation: formData.salutation,
+                firstName: formData.firstName,
+                lastName: formData.lastName,
+                birthDate: formData.birthDate,
+            });
+        setEditMode(false);
+    };
 
     const formatDate = (d) =>
         new Date(d).toLocaleDateString('de-DE', {
@@ -25,8 +60,38 @@ export default function DisabilityRequestModal({
             <div className="request-modal-grid" onClick={(e) => e.stopPropagation()}>
                 <h2>{user.visible_user_id ? user.visible_user_id : 'User'}</h2>
                 <div className="request-modal-grid-left">
-                    <p><strong>Name:</strong> <br/>{user.salutation} {user.firstName} {user.lastName}</p>
-                    <p><strong>Geburtsdatum:</strong> <br/>{formatDate(user.birth_date)}</p>
+                    {editMode ? (
+                        <>
+                            <label>
+                                <strong>Anrede:</strong>
+                                <select name="salutation" value={formData.salutation} onChange={handleChange}>
+                                    <option value="">Bitte wählen</option>
+                                    <option value="Herr">Herr</option>
+                                    <option value="Frau">Frau</option>
+                                    <option value="Dr.">Dr.</option>
+                                    <option value="Prof.">Prof.</option>
+                                    <option value="Divers">Divers</option>
+                                </select>
+                            </label>
+                            <label>
+                                <strong>Vorname:</strong>
+                                <input type="text" name="firstName" value={formData.firstName} onChange={handleChange} />
+                            </label>
+                            <label>
+                                <strong>Nachname:</strong>
+                                <input type="text" name="lastName" value={formData.lastName} onChange={handleChange} />
+                            </label>
+                            <label>
+                                <strong>Geburtsdatum:</strong>
+                                <input type="date" name="birthDate" value={formData.birthDate ? formData.birthDate.split('T')[0] : ''} onChange={handleChange} />
+                            </label>
+                        </>
+                    ) : (
+                        <>
+                            <p><strong>Name:</strong> <br/>{user.salutation} {user.firstName} {user.lastName}</p>
+                            <p><strong>Geburtsdatum:</strong> <br/>{formatDate(user.birth_date)}</p>
+                        </>
+                    )}
                     <p><strong>Grad der Behinderung:</strong> <br/>{detail.disability_degree}</p>
                     <p><strong>Ausweis gültig bis:</strong> <br/>{detail.disability_card_expiry_date === '9998-12-31T23:00:00.000Z' ? 'unbegrenzt' : formatDate(detail.disability_card_expiry_date)}</p>
                     <p><strong>Merkzeichen:</strong> <br/>{detail.marks && detail.marks.length ? detail.marks.join(', ') : 'Keine'}</p>
@@ -40,6 +105,12 @@ export default function DisabilityRequestModal({
                     )}
                 </div>
                 <div className="request-modal-actions">
+                    {canEdit && !editMode && (
+                        <button className="btn-edit" onClick={() => setEditMode(true)} title="Bearbeiten">✎</button>
+                    )}
+                    {canEdit && editMode && (
+                        <button className="btn-save" onClick={handleSave} title="Speichern">💾</button>
+                    )}
                     {onAccept && (
                         <button
                             className="profile__btn-cancel"
@@ -73,4 +144,6 @@ DisabilityRequestModal.propTypes = {
     onClose: PropTypes.func,
     onAccept: PropTypes.func,
     onDecline: PropTypes.func,
+    canEdit: PropTypes.bool,
+    onSave: PropTypes.func,
 };

--- a/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
+++ b/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
@@ -110,6 +110,27 @@ export default function CompensationRequests() {
         await Promise.all([fetchPending(), fetchAccepted()]);
     };
 
+    const saveUserProfile = async (updated) => {
+        if (!selectedUser) return;
+        try {
+            await fetch(`${API_BASE_URL}/service/users/${selectedUser.user_id}`, {
+                method: 'PATCH',
+                credentials: 'include',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(updated)
+            });
+            setSelectedUser(prev => ({
+                ...prev,
+                salutation: updated.salutation,
+                firstName: updated.firstName,
+                lastName: updated.lastName,
+                birth_date: updated.birthDate,
+            }));
+        } catch (err) {
+            console.error('Error saving profile:', err);
+        }
+    };
+
     const formatDate = (d) =>
         new Date(d).toLocaleDateString('de-DE', {
             weekday: 'long',
@@ -209,6 +230,8 @@ export default function CompensationRequests() {
                         onClose={closeModal}
                         onAccept={user?.hasDisabilityApprovalAccess ? acceptRequest : undefined}
                         onDecline={user?.hasDisabilityApprovalAccess ? declineRequest : undefined}
+                        canEdit={user?.hasAccountManagementAccess}
+                        onSave={saveUserProfile}
                     />
                 )}
             </div>


### PR DESCRIPTION
## Summary
- add server endpoint to patch other user profiles when staff have account management access
- allow editing user data in `DisabilityRequestModal`
- wire up editing capability in compensation requests page

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ca5c2e7083309128538daa8cf1a3