### PR TITLE
Add support editing for disability requests

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -1116,6 +1116,93 @@ app.patch('/users/:id/password', async (req, res) => {
     }
 });
 
+// PATCH: update user profile by admin/support
+app.patch('/users/:id/management', async (req, res) => {
+    if (!req.session.userId) {
+        return res.status(401).json({ message: 'Not logged in' });
+    }
+
+    try {
+        const { rows: permRows } = await client.query(
+            'SELECT has_account_management_access FROM user_roles WHERE id = $1',
+            [req.session.role]
+        );
+        if (!permRows.length || !permRows[0].has_account_management_access) {
+            return res.status(403).json({ message: 'Forbidden' });
+        }
+
+        const userId = req.params.id;
+        const {
+            salutation,
+            firstName,
+            lastName,
+            birthDate,
+            disabilityDegree,
+            disabilityCardExpiryDate,
+            marks = [],
+        } = req.body;
+
+        await client.query('BEGIN');
+
+        const { rows } = await client.query(
+            `UPDATE users
+                SET salutation = $1,
+                    first_name = $2,
+                    last_name = $3,
+                    birth_date = $4,
+                    disability_degree = $5,
+                    disability_card_expiry_date = $6,
+                    updated_at = NOW()
+             WHERE user_id = $7
+             RETURNING user_id,
+                       salutation AS "salutation",
+                       first_name AS "firstName",
+                       last_name AS "lastName",
+                       birth_date AS "birthDate",
+                       disability_degree AS "disabilityDegree",
+                       disability_card_expiry_date AS "disabilityCardExpiryDate"`,
+            [
+                salutation || null,
+                firstName?.trim() || '',
+                lastName?.trim() || '',
+                birthDate || null,
+                disabilityDegree || null,
+                disabilityCardExpiryDate || null,
+                userId,
+            ]
+        );
+
+        await client.query('DELETE FROM user_disability_marks WHERE user_id = $1', [userId]);
+        if (Array.isArray(marks)) {
+            for (const m of marks) {
+                await client.query(
+                    'INSERT INTO user_disability_marks (user_id, mark_code) VALUES ($1, $2)',
+                    [userId, m]
+                );
+            }
+        }
+
+        const { rows: markRows } = await client.query(
+            'SELECT mark_code FROM user_disability_marks WHERE user_id = $1',
+            [userId]
+        );
+
+        await client.query('COMMIT');
+
+        const updated = rows[0];
+        return res.json({
+            user: {
+                ...updated,
+                marks: markRows.map((m) => m.mark_code && m.mark_code.trim()),
+            },
+        });
+    } catch (err) {
+        await client.query('ROLLBACK');
+        console.error('Error updating user via management:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
 // Liefert alle verfügbaren Versandoptionen
 app.get('/shipping-options', async (req, res) => {
     try {

--- a/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
+++ b/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 export default function DisabilityRequestModal({
@@ -9,8 +9,51 @@ export default function DisabilityRequestModal({
     onClose,
     onAccept,
     onDecline,
+    onSave,
+    canEdit,
 }) {
     if (!user || !detail) return null;
+
+    const [editMode, setEditMode] = useState(false);
+    const [formData, setFormData] = useState({
+        salutation: user.salutation || '',
+        firstName: user.firstName || '',
+        lastName: user.lastName || '',
+        birthDate: user.birth_date || '',
+        disabilityDegree: detail.disability_degree || '',
+        disabilityCardExpiryDate: detail.disability_card_expiry_date || '',
+        marks: detail.marks || [],
+    });
+
+    useEffect(() => {
+        setFormData({
+            salutation: user.salutation || '',
+            firstName: user.firstName || '',
+            lastName: user.lastName || '',
+            birthDate: user.birth_date || '',
+            disabilityDegree: detail.disability_degree || '',
+            disabilityCardExpiryDate: detail.disability_card_expiry_date || '',
+            marks: detail.marks || [],
+        });
+    }, [user, detail]);
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setFormData((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const handleMarksChange = (e) => {
+        const val = e.target.value;
+        setFormData((prev) => ({
+            ...prev,
+            marks: val.split(',').map((s) => s.trim()).filter(Boolean),
+        }));
+    };
+
+    const handleSave = () => {
+        onSave && onSave(formData);
+        setEditMode(false);
+    };
 
     const formatDate = (d) =>
         new Date(d).toLocaleDateString('de-DE', {
@@ -25,11 +68,79 @@ export default function DisabilityRequestModal({
             <div className="request-modal-grid" onClick={(e) => e.stopPropagation()}>
                 <h2>{user.visible_user_id ? user.visible_user_id : 'User'}</h2>
                 <div className="request-modal-grid-left">
-                    <p><strong>Name:</strong> <br/>{user.salutation} {user.firstName} {user.lastName}</p>
-                    <p><strong>Geburtsdatum:</strong> <br/>{formatDate(user.birth_date)}</p>
-                    <p><strong>Grad der Behinderung:</strong> <br/>{detail.disability_degree}</p>
-                    <p><strong>Ausweis gültig bis:</strong> <br/>{detail.disability_card_expiry_date === '9998-12-31T23:00:00.000Z' ? 'unbegrenzt' : formatDate(detail.disability_card_expiry_date)}</p>
-                    <p><strong>Merkzeichen:</strong> <br/>{detail.marks && detail.marks.length ? detail.marks.join(', ') : 'Keine'}</p>
+                    {editMode ? (
+                        <>
+                            <input
+                                type="text"
+                                name="salutation"
+                                value={formData.salutation}
+                                onChange={handleChange}
+                                placeholder="Anrede"
+                                className="input-name"
+                            />
+                            <input
+                                type="text"
+                                name="firstName"
+                                value={formData.firstName}
+                                onChange={handleChange}
+                                placeholder="Vorname"
+                                className="input-name"
+                            />
+                            <input
+                                type="text"
+                                name="lastName"
+                                value={formData.lastName}
+                                onChange={handleChange}
+                                placeholder="Nachname"
+                                className="input-name"
+                            />
+                            <input
+                                type="date"
+                                name="birthDate"
+                                value={formData.birthDate ? formData.birthDate.split('T')[0] : ''}
+                                onChange={handleChange}
+                                className="input-name"
+                            />
+                            <input
+                                type="number"
+                                name="disabilityDegree"
+                                value={formData.disabilityDegree || ''}
+                                onChange={handleChange}
+                                className="input-name"
+                                placeholder="Grad der Behinderung"
+                            />
+                            <input
+                                type="date"
+                                name="disabilityCardExpiryDate"
+                                value={formData.disabilityCardExpiryDate ? formData.disabilityCardExpiryDate.split('T')[0] : ''}
+                                onChange={handleChange}
+                                className="input-name"
+                            />
+                            <input
+                                type="text"
+                                name="marks"
+                                value={formData.marks.join(', ')}
+                                onChange={handleMarksChange}
+                                placeholder="Merkzeichen (kommagetrennt)"
+                                className="input-name"
+                            />
+                        </>
+                    ) : (
+                        <>
+                            <p><strong>Name:</strong> <br/>{user.salutation} {user.firstName} {user.lastName}</p>
+                            <p><strong>Geburtsdatum:</strong> <br/>{formatDate(user.birth_date)}</p>
+                            <p><strong>Grad der Behinderung:</strong> <br/>{detail.disability_degree}</p>
+                            <p><strong>Ausweis gültig bis:</strong> <br/>{detail.disability_card_expiry_date === '9998-12-31T23:00:00.000Z' ? 'unbegrenzt' : formatDate(detail.disability_card_expiry_date)}</p>
+                            <p><strong>Merkzeichen:</strong> <br/>{detail.marks && detail.marks.length ? detail.marks.join(', ') : 'Keine'}</p>
+                        </>
+                    )}
+                    {canEdit && (
+                        editMode ? (
+                            <button className="btn-save" onClick={handleSave} title="Speichern">💾</button>
+                        ) : (
+                            <button className="btn-edit" onClick={() => setEditMode(true)} title="Bearbeiten">✎</button>
+                        )
+                    )}
                 </div>
                 <div className="request-modal-grid-images">
                     {imgFrontUrl && (
@@ -73,4 +184,6 @@ DisabilityRequestModal.propTypes = {
     onClose: PropTypes.func,
     onAccept: PropTypes.func,
     onDecline: PropTypes.func,
+    onSave: PropTypes.func,
+    canEdit: PropTypes.bool,
 };

--- a/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
+++ b/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
@@ -110,6 +110,36 @@ export default function CompensationRequests() {
         await Promise.all([fetchPending(), fetchAccepted()]);
     };
 
+    const saveUserData = async (data) => {
+        if (!selectedUser) return;
+        try {
+            const res = await fetch(`${API_BASE_URL}/users/${selectedUser.user_id}/management`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'include',
+                body: JSON.stringify(data),
+            });
+            if (res.ok) {
+                const js = await res.json();
+                setSelectedUser(prev => ({
+                    ...prev,
+                    salutation: js.user.salutation,
+                    firstName: js.user.firstName,
+                    lastName: js.user.lastName,
+                    birth_date: js.user.birthDate,
+                }));
+                setDetail(prev => ({
+                    ...prev,
+                    disability_degree: js.user.disabilityDegree,
+                    disability_card_expiry_date: js.user.disabilityCardExpiryDate,
+                    marks: js.user.marks,
+                }));
+            }
+        } catch (err) {
+            console.error('Error saving user data:', err);
+        }
+    };
+
     const formatDate = (d) =>
         new Date(d).toLocaleDateString('de-DE', {
             weekday: 'long',
@@ -209,6 +239,8 @@ export default function CompensationRequests() {
                         onClose={closeModal}
                         onAccept={user?.hasDisabilityApprovalAccess ? acceptRequest : undefined}
                         onDecline={user?.hasDisabilityApprovalAccess ? declineRequest : undefined}
+                        onSave={user?.hasAccountManagementAccess ? saveUserData : undefined}
+                        canEdit={user?.hasAccountManagementAccess}
                     />
                 )}
             </div>


### PR DESCRIPTION
## Summary
- allow account-management roles to edit user profiles from disability requests
- add admin patch endpoint for updating user data
- enable editing fields in DisabilityRequestModal
- wire editing feature into compensation requests page

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ca5c2e7083309128538daa8cf1a3