### PR TITLE
Add service edit functionality for disability requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Die wichtigsten Routen des Express-Servers (siehe `server/server.js`) sind:
 | `GET`   | `/pending-disability-requests` | Offene Anträge auf Nachteilsausgleich für den Service-Bereich |
 | `POST`  | `/disability-requests/:id/accept` | Antrag eines Nutzers akzeptieren |
 | `POST`  | `/disability-requests/:id/decline` | Antrag eines Nutzers ablehnen |
+| `PATCH` | `/users/:id/support` | Profildaten eines Nutzers durch Service bearbeiten |
 | `GET`   | `/artists` | Auflistung aller Künstler |
 | `POST`  | `/create-artist` | Neuen Künstler anlegen |
 | `GET`   | `/tours-detailed` | Touren inkl. Events und Zugänglichkeitsdaten |

--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -1064,6 +1064,65 @@ app.patch('/users/:id', async (req, res) => {
     }
 });
 
+// PATCH: Support/Service can update a user's profile
+app.patch('/users/:id/support', async (req, res) => {
+    if (!req.session.userId) {
+        return res.status(401).json({ message: 'Not logged in' });
+    }
+    if (!req.session.hasAccountManagementAccess) {
+        return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    const userId = req.params.id;
+    const {
+        salutation,
+        firstName,
+        lastName,
+        birthDate,
+        disabilityDegree,
+        disabilityCardExpiryDate,
+        marks
+    } = req.body;
+
+    try {
+        await client.query(
+            `UPDATE users
+                SET salutation = $1,
+                    first_name = $2,
+                    last_name = $3,
+                    birth_date = $4,
+                    disability_degree = $5,
+                    disability_card_expiry_date = $6,
+                    updated_at = NOW()
+              WHERE user_id = $7`,
+            [
+                salutation || null,
+                firstName || null,
+                lastName || null,
+                birthDate || null,
+                disabilityDegree || null,
+                disabilityCardExpiryDate || '9999-01-01',
+                userId,
+            ]
+        );
+
+        await client.query('DELETE FROM user_disability_marks WHERE user_id = $1', [userId]);
+        if (Array.isArray(marks)) {
+            for (const m of marks) {
+                await client.query(
+                    'INSERT INTO user_disability_marks (user_id, mark_code) VALUES ($1, $2)',
+                    [userId, m]
+                );
+            }
+        }
+
+        return res.json({ message: 'User updated' });
+    } catch (err) {
+        console.error('Error updating user by support:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
 
 // Passwort eines Nutzers ändern
 app.patch('/users/:id/password', async (req, res) => {

--- a/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
+++ b/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 
 export default function DisabilityRequestModal({
@@ -9,6 +9,8 @@ export default function DisabilityRequestModal({
     onClose,
     onAccept,
     onDecline,
+    canEdit = false,
+    onSave,
 }) {
     if (!user || !detail) return null;
 
@@ -20,16 +22,130 @@ export default function DisabilityRequestModal({
             year: 'numeric',
         });
 
+    const [editMode, setEditMode] = useState(false);
+    const [form, setForm] = useState({
+        salutation: '',
+        firstName: '',
+        lastName: '',
+        birthDate: '',
+        disabilityDegree: '',
+        disabilityCardExpiryDate: '',
+        marks: '',
+    });
+
+    useEffect(() => {
+        if (user && detail) {
+            setForm({
+                salutation: user.salutation || '',
+                firstName: user.firstName || '',
+                lastName: user.lastName || '',
+                birthDate: user.birth_date ? user.birth_date.split('T')[0] : '',
+                disabilityDegree: detail.disability_degree || '',
+                disabilityCardExpiryDate: detail.disability_card_expiry_date
+                    ? detail.disability_card_expiry_date.split('T')[0]
+                    : '',
+                marks: Array.isArray(detail.marks) ? detail.marks.join(', ') : '',
+            });
+        }
+    }, [user, detail]);
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setForm((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const handleSave = () => {
+        onSave &&
+            onSave({
+                salutation: form.salutation,
+                firstName: form.firstName,
+                lastName: form.lastName,
+                birthDate: form.birthDate,
+                disabilityDegree: form.disabilityDegree,
+                disabilityCardExpiryDate: form.disabilityCardExpiryDate,
+                marks: form.marks
+                    .split(',')
+                    .map((m) => m.trim())
+                    .filter((m) => m),
+            });
+        setEditMode(false);
+    };
+
     return (
         <div className="service__modal-overlay" onClick={onClose}>
             <div className="request-modal-grid" onClick={(e) => e.stopPropagation()}>
                 <h2>{user.visible_user_id ? user.visible_user_id : 'User'}</h2>
                 <div className="request-modal-grid-left">
-                    <p><strong>Name:</strong> <br/>{user.salutation} {user.firstName} {user.lastName}</p>
-                    <p><strong>Geburtsdatum:</strong> <br/>{formatDate(user.birth_date)}</p>
-                    <p><strong>Grad der Behinderung:</strong> <br/>{detail.disability_degree}</p>
-                    <p><strong>Ausweis gültig bis:</strong> <br/>{detail.disability_card_expiry_date === '9998-12-31T23:00:00.000Z' ? 'unbegrenzt' : formatDate(detail.disability_card_expiry_date)}</p>
-                    <p><strong>Merkzeichen:</strong> <br/>{detail.marks && detail.marks.length ? detail.marks.join(', ') : 'Keine'}</p>
+                    {canEdit && !editMode && (
+                        <button className="btn-edit" onClick={() => setEditMode(true)} title="Bearbeiten">✎</button>
+                    )}
+                    {editMode ? (
+                        <>
+                            <input
+                                type="text"
+                                name="salutation"
+                                value={form.salutation}
+                                onChange={handleChange}
+                                placeholder="Anrede"
+                                className="input-name"
+                            />
+                            <input
+                                type="text"
+                                name="firstName"
+                                value={form.firstName}
+                                onChange={handleChange}
+                                placeholder="Vorname"
+                                className="input-name"
+                            />
+                            <input
+                                type="text"
+                                name="lastName"
+                                value={form.lastName}
+                                onChange={handleChange}
+                                placeholder="Nachname"
+                                className="input-name"
+                            />
+                            <input
+                                type="date"
+                                name="birthDate"
+                                value={form.birthDate}
+                                onChange={handleChange}
+                                className="input-name"
+                            />
+                            <input
+                                type="number"
+                                name="disabilityDegree"
+                                value={form.disabilityDegree}
+                                onChange={handleChange}
+                                placeholder="Grad der Behinderung"
+                                className="input-name"
+                            />
+                            <input
+                                type="date"
+                                name="disabilityCardExpiryDate"
+                                value={form.disabilityCardExpiryDate}
+                                onChange={handleChange}
+                                className="input-name"
+                            />
+                            <input
+                                type="text"
+                                name="marks"
+                                value={form.marks}
+                                onChange={handleChange}
+                                placeholder="Merkzeichen, Komma-getrennt"
+                                className="input-name"
+                            />
+                            <button className="btn-save" onClick={handleSave} title="Speichern">💾</button>
+                        </>
+                    ) : (
+                        <>
+                            <p><strong>Name:</strong> <br/>{user.salutation} {user.firstName} {user.lastName}</p>
+                            <p><strong>Geburtsdatum:</strong> <br/>{formatDate(user.birth_date)}</p>
+                            <p><strong>Grad der Behinderung:</strong> <br/>{detail.disability_degree}</p>
+                            <p><strong>Ausweis gültig bis:</strong> <br/>{detail.disability_card_expiry_date === '9998-12-31T23:00:00.000Z' ? 'unbegrenzt' : formatDate(detail.disability_card_expiry_date)}</p>
+                            <p><strong>Merkzeichen:</strong> <br/>{detail.marks && detail.marks.length ? detail.marks.join(', ') : 'Keine'}</p>
+                        </>
+                    )}
                 </div>
                 <div className="request-modal-grid-images">
                     {imgFrontUrl && (
@@ -73,4 +189,6 @@ DisabilityRequestModal.propTypes = {
     onClose: PropTypes.func,
     onAccept: PropTypes.func,
     onDecline: PropTypes.func,
+    canEdit: PropTypes.bool,
+    onSave: PropTypes.func,
 };

--- a/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
+++ b/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
@@ -110,6 +110,21 @@ export default function CompensationRequests() {
         await Promise.all([fetchPending(), fetchAccepted()]);
     };
 
+    const saveUserData = async (data) => {
+        if (!selectedUser) return;
+        try {
+            await fetch(`${API_BASE_URL}/users/${selectedUser.user_id}/support`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(data)
+            });
+            await loadDetail(selectedUser);
+            await Promise.all([fetchPending(), fetchAccepted()]);
+        } catch (err) {
+            console.error('Error saving user data:', err);
+        }
+    };
+
     const formatDate = (d) =>
         new Date(d).toLocaleDateString('de-DE', {
             weekday: 'long',
@@ -209,6 +224,8 @@ export default function CompensationRequests() {
                         onClose={closeModal}
                         onAccept={user?.hasDisabilityApprovalAccess ? acceptRequest : undefined}
                         onDecline={user?.hasDisabilityApprovalAccess ? declineRequest : undefined}
+                        canEdit={user?.hasAccountManagementAccess}
+                        onSave={saveUserData}
                     />
                 )}
             </div>


### PR DESCRIPTION
## Summary
- allow service staff to edit user data directly in disability request modal
- enable editing UI in `DisabilityRequestModal`
- add PATCH endpoint `/users/:id/support` on server for account management
- document new endpoint in README

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ca5c2e7083309128538daa8cf1a3