### PR TITLE
Enable service user profile editing

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -1116,6 +1116,87 @@ app.patch('/users/:id/password', async (req, res) => {
     }
 });
 
+// PATCH: update disability related data via service
+app.patch('/service/users/:id', async (req, res) => {
+    const sessionUser = req.session.userId;
+    if (!sessionUser) {
+        return res.status(401).json({ message: 'Not logged in' });
+    }
+
+    const paramUserId = req.params.id;
+    if (sessionUser !== paramUserId && !req.session.hasAccountManagementAccess) {
+        return res.status(403).json({ message: 'Forbidden' });
+    }
+
+    const {
+        salutation,
+        firstName,
+        lastName,
+        birthDate,
+        disabilityDegree,
+        disabilityCardExpiryDate,
+        disabilityMarks = []
+    } = req.body || {};
+
+    try {
+        await client.query(
+            `UPDATE users
+                SET salutation = $1,
+                    first_name = $2,
+                    last_name  = $3,
+                    birth_date = $4,
+                    disability_degree = $5,
+                    disability_card_expiry_date = $6,
+                    updated_at = NOW()
+              WHERE user_id = $7`,
+            [
+                salutation || null,
+                firstName || null,
+                lastName || null,
+                birthDate || null,
+                disabilityDegree || null,
+                disabilityCardExpiryDate || null,
+                paramUserId
+            ]
+        );
+
+        await client.query('DELETE FROM user_disability_marks WHERE user_id = $1', [paramUserId]);
+        if (Array.isArray(disabilityMarks)) {
+            for (const m of disabilityMarks) {
+                await client.query(
+                    'INSERT INTO user_disability_marks (user_id, mark_code) VALUES ($1,$2)',
+                    [paramUserId, m]
+                );
+            }
+        }
+
+        const { rows } = await client.query(
+            `SELECT salutation, first_name, last_name, birth_date, disability_degree, disability_card_expiry_date
+               FROM users WHERE user_id = $1`,
+            [paramUserId]
+        );
+        const { rows: markRows } = await client.query(
+            'SELECT mark_code FROM user_disability_marks WHERE user_id = $1',
+            [paramUserId]
+        );
+
+        return res.json({
+            user: {
+                salutation: rows[0].salutation,
+                firstName: rows[0].first_name,
+                lastName: rows[0].last_name,
+                birth_date: rows[0].birth_date,
+                disability_degree: rows[0].disability_degree,
+                disability_card_expiry_date: rows[0].disability_card_expiry_date
+            },
+            marks: markRows.map(m => m.mark_code && m.mark_code.trim())
+        });
+    } catch (err) {
+        console.error('Error updating user via service:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
 // Liefert alle verfügbaren Versandoptionen
 app.get('/shipping-options', async (req, res) => {
     try {

--- a/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
+++ b/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import { API_BASE_URL } from '../config';
 
 export default function DisabilityRequestModal({
     user,
@@ -9,8 +10,50 @@ export default function DisabilityRequestModal({
     onClose,
     onAccept,
     onDecline,
+    canEdit = false,
+    onSave,
 }) {
     if (!user || !detail) return null;
+
+    const [editMode, setEditMode] = useState(false);
+    const [formData, setFormData] = useState({
+        salutation: '',
+        firstName: '',
+        lastName: '',
+        birthDate: '',
+        disabilityDegree: '',
+        disabilityCardExpiryDate: '',
+        disabilityMarks: [],
+    });
+    const [marksOptions, setMarksOptions] = useState([]);
+
+    useEffect(() => {
+        if (user && detail) {
+            setFormData({
+                salutation: user.salutation || '',
+                firstName: user.firstName || '',
+                lastName: user.lastName || '',
+                birthDate: user.birth_date ? user.birth_date.split('T')[0] : '',
+                disabilityDegree: detail.disability_degree || '',
+                disabilityCardExpiryDate: detail.disability_card_expiry_date
+                    ? detail.disability_card_expiry_date.split('T')[0]
+                    : '',
+                disabilityMarks: detail.marks || [],
+            });
+        }
+    }, [user, detail]);
+
+    const fetchMarks = async () => {
+        try {
+            const r = await fetch(`${API_BASE_URL}/disability-marks`);
+            if (r.ok) {
+                const js = await r.json();
+                setMarksOptions(js.marks || []);
+            }
+        } catch (err) {
+            console.error('Error loading marks:', err);
+        }
+    };
 
     const formatDate = (d) =>
         new Date(d).toLocaleDateString('de-DE', {
@@ -20,16 +63,81 @@ export default function DisabilityRequestModal({
             year: 'numeric',
         });
 
+    const toggleEdit = async () => {
+        if (!editMode && marksOptions.length === 0) {
+            await fetchMarks();
+        }
+        setEditMode(!editMode);
+    };
+
+    const handleChange = (e) => {
+        const { name, value } = e.target;
+        setFormData((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const toggleMark = (code) => {
+        setFormData((prev) => ({
+            ...prev,
+            disabilityMarks: prev.disabilityMarks.includes(code)
+                ? prev.disabilityMarks.filter((m) => m !== code)
+                : [...prev.disabilityMarks, code],
+        }));
+    };
+
+    const saveChanges = async () => {
+        if (onSave) {
+            await onSave(formData);
+        }
+        setEditMode(false);
+    };
+
     return (
         <div className="service__modal-overlay" onClick={onClose}>
             <div className="request-modal-grid" onClick={(e) => e.stopPropagation()}>
                 <h2>{user.visible_user_id ? user.visible_user_id : 'User'}</h2>
                 <div className="request-modal-grid-left">
-                    <p><strong>Name:</strong> <br/>{user.salutation} {user.firstName} {user.lastName}</p>
-                    <p><strong>Geburtsdatum:</strong> <br/>{formatDate(user.birth_date)}</p>
-                    <p><strong>Grad der Behinderung:</strong> <br/>{detail.disability_degree}</p>
-                    <p><strong>Ausweis gültig bis:</strong> <br/>{detail.disability_card_expiry_date === '9998-12-31T23:00:00.000Z' ? 'unbegrenzt' : formatDate(detail.disability_card_expiry_date)}</p>
-                    <p><strong>Merkzeichen:</strong> <br/>{detail.marks && detail.marks.length ? detail.marks.join(', ') : 'Keine'}</p>
+                    {!editMode ? (
+                        <>
+                            <p><strong>Name:</strong> <br/>{user.salutation} {user.firstName} {user.lastName}</p>
+                            <p><strong>Geburtsdatum:</strong> <br/>{formatDate(user.birth_date)}</p>
+                            <p><strong>Grad der Behinderung:</strong> <br/>{detail.disability_degree}</p>
+                            <p><strong>Ausweis gültig bis:</strong> <br/>{detail.disability_card_expiry_date === '9998-12-31T23:00:00.000Z' ? 'unbegrenzt' : formatDate(detail.disability_card_expiry_date)}</p>
+                            <p><strong>Merkzeichen:</strong> <br/>{detail.marks && detail.marks.length ? detail.marks.join(', ') : 'Keine'}</p>
+                        </>
+                    ) : (
+                        <>
+                            <label htmlFor="salutation">Anrede</label>
+                            <select name="salutation" id="salutation" value={formData.salutation} onChange={handleChange}>
+                                <option value="">Bitte wählen</option>
+                                <option value="Herr">Herr</option>
+                                <option value="Frau">Frau</option>
+                                <option value="Dr.">Dr.</option>
+                                <option value="Prof.">Prof.</option>
+                            </select>
+                            <label htmlFor="firstName">Vorname</label>
+                            <input name="firstName" id="firstName" value={formData.firstName} onChange={handleChange} />
+                            <label htmlFor="lastName">Nachname</label>
+                            <input name="lastName" id="lastName" value={formData.lastName} onChange={handleChange} />
+                            <label htmlFor="birthDate">Geburtsdatum</label>
+                            <input type="date" name="birthDate" id="birthDate" value={formData.birthDate} onChange={handleChange} />
+                            <label htmlFor="disabilityDegree">Grad der Behinderung</label>
+                            <input name="disabilityDegree" id="disabilityDegree" value={formData.disabilityDegree} onChange={handleChange} />
+                            <label htmlFor="disabilityCardExpiryDate">Ausweis gültig bis</label>
+                            <input type="date" name="disabilityCardExpiryDate" id="disabilityCardExpiryDate" value={formData.disabilityCardExpiryDate} onChange={handleChange} />
+                            <label>Merkzeichen</label>
+                            <div className="marks-grid">
+                                {marksOptions.map(mark => {
+                                    const sel = formData.disabilityMarks.includes(mark.mark_code);
+                                    return (
+                                        <div key={mark.mark_code} className={`mark-card ${sel ? 'mark-card--selected' : ''}`} onClick={() => toggleMark(mark.mark_code)}>
+                                            <input type="checkbox" id={`mark-${mark.mark_code}`} checked={sel} onChange={() => toggleMark(mark.mark_code)} className="mark-card__checkbox" />
+                                            <label htmlFor={`mark-${mark.mark_code}`} className="mark-card__label">{mark.mark_code} – {mark.description}</label>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </>
+                    )}
                 </div>
                 <div className="request-modal-grid-images">
                     {imgFrontUrl && (
@@ -40,7 +148,7 @@ export default function DisabilityRequestModal({
                     )}
                 </div>
                 <div className="request-modal-actions">
-                    {onAccept && (
+                    {onAccept && !editMode && (
                         <button
                             className="profile__btn-cancel"
                             style={{ backgroundColor: 'green' }}
@@ -49,8 +157,15 @@ export default function DisabilityRequestModal({
                             ✓
                         </button>
                     )}
+                    {canEdit && (
+                        !editMode ? (
+                            <button className="profile__btn-cancel" onClick={toggleEdit}>Bearbeiten</button>
+                        ) : (
+                            <button className="profile__btn-cancel" onClick={saveChanges}>Speichern</button>
+                        )
+                    )}
                     <button className="profile__btn-cancel" onClick={onClose} style={{backgroundColor: 'grey'}}>Schließen</button>
-                    {onDecline && (
+                    {onDecline && !editMode && (
                         <button
                             className="profile__btn-cancel"
                             style={{ backgroundColor: 'red' }}
@@ -73,4 +188,6 @@ DisabilityRequestModal.propTypes = {
     onClose: PropTypes.func,
     onAccept: PropTypes.func,
     onDecline: PropTypes.func,
+    canEdit: PropTypes.bool,
+    onSave: PropTypes.func,
 };

--- a/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
+++ b/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
@@ -110,6 +110,36 @@ export default function CompensationRequests() {
         await Promise.all([fetchPending(), fetchAccepted()]);
     };
 
+    const saveEditedData = async (data) => {
+        if (!selectedUser) return;
+        try {
+            const res = await fetch(`${API_BASE_URL}/service/users/${selectedUser.user_id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'include',
+                body: JSON.stringify(data),
+            });
+            if (res.ok) {
+                const js = await res.json();
+                setSelectedUser(prev => ({
+                    ...prev,
+                    salutation: js.user.salutation,
+                    firstName: js.user.firstName,
+                    lastName: js.user.lastName,
+                    birth_date: js.user.birth_date,
+                }));
+                setDetail(prev => ({
+                    ...prev,
+                    disability_degree: js.user.disability_degree,
+                    disability_card_expiry_date: js.user.disability_card_expiry_date,
+                    marks: js.marks,
+                }));
+            }
+        } catch (err) {
+            console.error('Error saving data:', err);
+        }
+    };
+
     const formatDate = (d) =>
         new Date(d).toLocaleDateString('de-DE', {
             weekday: 'long',
@@ -209,6 +239,8 @@ export default function CompensationRequests() {
                         onClose={closeModal}
                         onAccept={user?.hasDisabilityApprovalAccess ? acceptRequest : undefined}
                         onDecline={user?.hasDisabilityApprovalAccess ? declineRequest : undefined}
+                        canEdit={user?.hasAccountManagementAccess}
+                        onSave={saveEditedData}
                     />
                 )}
             </div>


### PR DESCRIPTION
## Summary
- allow service to patch disability information via new endpoint
- add edit mode to disability request modal
- expose save callback from compensation page

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867dc68857c8330956f1e1a19b0c17b