### PR TITLE
Improve validation and deletion checks

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -1607,6 +1607,21 @@ app.post('/create-venue', upload.single('venueImage'), async (req, res) => {
         areas = [];
     }
 
+    if (areas.length === 0 ||
+        !areas.some(a => a.areaId && parseInt(a.maxCapacity, 10) > 0)) {
+        return res.status(400).json({
+            message: 'Mindestens ein Bereich mit Kapazität > 0 ist erforderlich'
+        });
+    }
+
+    for (const area of areas) {
+        if (!area.areaId || parseInt(area.maxCapacity, 10) <= 0) {
+            return res.status(400).json({
+                message: 'Alle Bereiche benötigen gültige IDs und Kapazität > 0'
+            });
+        }
+    }
+
     if (!name?.trim() || !address?.trim() || !cityId) {
         return res.status(400).json({
             message: 'Name, Adresse und Stadt sind erforderlich'
@@ -1724,6 +1739,20 @@ app.put('/venues/:id', upload.single('venue_image'), async (req, res) => {
         venueAreas = [];
     }
 
+    if (venueAreas.length === 0 ||
+        !venueAreas.some(a => a.areaId && parseInt(a.maxCapacity, 10) > 0)) {
+        return res.status(400).json({
+            message: 'Mindestens ein Bereich mit Kapazität > 0 ist erforderlich'
+        });
+    }
+    for (const va of venueAreas) {
+        if (!va.areaId || parseInt(va.maxCapacity, 10) <= 0) {
+            return res.status(400).json({
+                message: 'Alle Bereiche benötigen gültige IDs und Kapazität > 0'
+            });
+        }
+    }
+
     if (!name?.trim() || !address?.trim() || !cityId) {
         return res
             .status(400)
@@ -1811,6 +1840,32 @@ app.put('/venues/:id', upload.single('venue_image'), async (req, res) => {
 app.delete('/venues/:id', async (req, res) => {
     const venueId = req.params.id;
     try {
+        // Prüfen, ob noch Events oder Tickets existieren
+        const { rows: ticketRows } = await client.query(
+            `SELECT 1
+               FROM tickets t
+                        JOIN event_categories ec ON ec.id = t.event_category_id
+                        JOIN events e ON e.id = ec.event_id
+              WHERE e.venue_id = $1
+              LIMIT 1`,
+            [venueId]
+        );
+        if (ticketRows.length > 0) {
+            return res.status(400).json({
+                message: 'Venue kann nicht gelöscht werden, da Tickets für Events existieren.'
+            });
+        }
+
+        const { rows: eventRows } = await client.query(
+            'SELECT 1 FROM events WHERE venue_id = $1 LIMIT 1',
+            [venueId]
+        );
+        if (eventRows.length > 0) {
+            return res.status(400).json({
+                message: 'Venue kann nicht gelöscht werden, solange noch Events vorhanden sind.'
+            });
+        }
+
         await client.query('BEGIN');
         await client.query('DELETE FROM venue_areas WHERE venue_id = $1', [venueId]);
         await client.query('DELETE FROM venues WHERE id = $1', [venueId]);
@@ -1836,6 +1891,20 @@ app.post('/create-event', express.json(), async (req, res) => {
 
     if (!tourId || !venueId || !doorTime || !startTime || !endTime) {
         return res.status(400).json({ message: 'Tour, Venue und alle Zeitangaben sind erforderlich' });
+    }
+
+    if (!Array.isArray(categories) || categories.length === 0) {
+        return res.status(400).json({ message: 'Mindestens eine Kategorie ist erforderlich' });
+    }
+    for (const cat of categories) {
+        if (!Array.isArray(cat.venueAreas) || cat.venueAreas.length === 0) {
+            return res.status(400).json({ message: 'Jede Kategorie benötigt mindestens einen Bereich' });
+        }
+        for (const entry of cat.venueAreas) {
+            if (!entry.areaId || parseInt(entry.capacity, 10) <= 0) {
+                return res.status(400).json({ message: 'Alle Bereichszuordnungen benötigen gültige IDs und Kapazität > 0' });
+            }
+        }
     }
 
     try {
@@ -2378,6 +2447,42 @@ app.put('/artists/:id', upload.single('artist_image'), async (req, res) => {
 app.delete('/artists/:id', async (req, res) => {
     const artistId = req.params.id;
     try {
+        const { rows: ticketRows } = await client.query(
+            `SELECT 1
+               FROM tickets t
+                        JOIN event_categories ec ON ec.id = t.event_category_id
+                        JOIN events e ON e.id = ec.event_id
+                        JOIN event_supporting_acts esa ON esa.event_id = e.id
+              WHERE esa.artist_id = $1
+              LIMIT 1`,
+            [artistId]
+        );
+        if (ticketRows.length > 0) {
+            return res.status(400).json({
+                message: 'Artist kann nicht gelöscht werden, da Tickets für Events existieren.'
+            });
+        }
+
+        const { rows: refRows } = await client.query(
+            'SELECT 1 FROM event_supporting_acts WHERE artist_id = $1 LIMIT 1',
+            [artistId]
+        );
+        if (refRows.length > 0) {
+            return res.status(400).json({
+                message: 'Artist kann nicht gelöscht werden, da Events auf ihn verweisen.'
+            });
+        }
+
+        const { rows: tourRef } = await client.query(
+            'SELECT 1 FROM tour_artists WHERE artist_id = $1 LIMIT 1',
+            [artistId]
+        );
+        if (tourRef.length > 0) {
+            return res.status(400).json({
+                message: 'Artist kann nicht gelöscht werden, da Touren auf ihn verweisen.'
+            });
+        }
+
         // 1) hole artist_image id
         const { rows } = await client.query(
             'SELECT artist_image FROM artists WHERE id = $1',

--- a/eventim-disability-integration/src/pages/admin/artists/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/artists/index.jsx
@@ -112,7 +112,9 @@ export default function ArtistsContent() {
                 method: 'DELETE',
             });
             if (!response.ok) {
-                throw new Error('Server-Fehler beim Löschen');
+                const d = await response.json().catch(() => ({}));
+                alert(d.message || 'Server-Fehler beim Löschen');
+                return;
             }
             setConfirmDeleteId(null);
             fetchArtists();

--- a/eventim-disability-integration/src/pages/admin/venues/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/create.jsx
@@ -79,9 +79,14 @@ export default function VenueCreation() {
             setLoading(false);
             return;
         }
+        if (venueAreas.length === 0) {
+            setMessage('Mindestens ein Bereich mit Kapazität > 0 ist erforderlich');
+            setLoading(false);
+            return;
+        }
         for (const va of venueAreas) {
-            if (!va.areaId || !va.maxCapacity) {
-                setMessage('Alle Bereiche benötigen eine Kapazität und Auswahl');
+            if (!va.areaId || !va.maxCapacity || parseInt(va.maxCapacity, 10) <= 0) {
+                setMessage('Alle Bereiche benötigen eine Kapazität > 0 und Auswahl');
                 setLoading(false);
                 return;
             }

--- a/eventim-disability-integration/src/pages/admin/venues/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/index.jsx
@@ -122,6 +122,17 @@ export default function VenuesContent() {
 
     const handleSave = async () => {
         try {
+            if (venueAreas.length === 0 ||
+                !venueAreas.some(v => v.areaId && parseInt(v.maxCapacity, 10) > 0)) {
+                alert('Mindestens ein Bereich mit Kapazität > 0 ist erforderlich');
+                return;
+            }
+            for (const v of venueAreas) {
+                if (!v.areaId || !v.maxCapacity || parseInt(v.maxCapacity, 10) <= 0) {
+                    alert('Alle Bereiche benötigen eine Kapazität > 0 und Auswahl');
+                    return;
+                }
+            }
             const fd = new FormData();
             fd.append('name', editedData.name);
             fd.append('address', editedData.address);
@@ -136,7 +147,10 @@ export default function VenuesContent() {
                 method: 'PUT',
                 body: fd,
             });
-            if (!response.ok) throw new Error('Server-Fehler beim Speichern');
+            if (!response.ok) {
+                const d = await response.json().catch(() => ({}));
+                throw new Error(d.message || 'Server-Fehler beim Speichern');
+            }
             setEditingId(null);
             fetchVenues();
         } catch (err) {
@@ -149,7 +163,11 @@ export default function VenuesContent() {
             const response = await fetch(`http://localhost:4000/venues/${id}`, {
                 method: 'DELETE',
             });
-            if (!response.ok) throw new Error('Server-Fehler beim Löschen');
+            if (!response.ok) {
+                const d = await response.json().catch(() => ({}));
+                alert(d.message || 'Server-Fehler beim Löschen');
+                return;
+            }
             setConfirmDeleteId(null);
             fetchVenues();
         } catch (err) {


### PR DESCRIPTION
## Summary
- add validation for venue area input on create and update
- ensure venues cannot be deleted when events or tickets exist
- validate event categories on creation
- block artist deletion when referenced
- add client‑side checks for venues and artists

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f726ee40833088bfb935006ee674