### PR TITLE
Implement disabled ticket purchase check

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -4243,6 +4243,32 @@ app.get('/orders', async (req, res) => {
     }
 });
 
+// Liefert die Anzahl bereits gekaufter Behinderten-Tickets für ein bestimmtes Event
+app.get('/event-disabled-ticket-count/:eventId', async (req, res) => {
+    const userId = req.session.userId;
+    if (!userId) return res.status(401).json({ message: 'Not logged in' });
+    const eventId = req.params.eventId;
+
+    try {
+        const { rows } = await client.query(
+            `SELECT COUNT(*) AS count
+             FROM tickets t
+                      JOIN event_categories ec ON ec.id = t.event_category_id
+                      JOIN orders o          ON o.id = t.order_id
+             WHERE o.user_id = $1
+               AND ec.event_id = $2
+               AND t.is_assistance_ticket = false
+               AND ec.disability_support_for IS NOT NULL`,
+            [userId, eventId]
+        );
+        const count = parseInt(rows[0].count, 10) || 0;
+        return res.json({ count });
+    } catch (err) {
+        console.error('Error fetching disabled ticket count:', err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+});
+
 // Liefert alle Events, für die der eingeloggte Nutzer Tickets besitzt
 app.get('/my-events', async (req, res) => {
     const userId = req.session.userId;

--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
@@ -29,6 +29,7 @@ export default function EventPage() {
     const [lastClickedSection, setLastClickedSection] = useState(null);  // 'disabled' or 'regular'
     const [addDisabled, setAddDisabled] = useState(false);
     const [assistanceInCart, setAssistanceInCart] = useState(false);
+    const [disabledPurchased, setDisabledPurchased] = useState(0);
 
     // Redirect to 404 page if event data could not be loaded within 3 seconds
     useEffect(() => {
@@ -62,6 +63,29 @@ export default function EventPage() {
             setBookingForMe(false);
         }
     }, [assistanceInCart]);
+
+    useEffect(() => {
+        if (!loggedIn || !event) {
+            setDisabledPurchased(0);
+            return;
+        }
+        const load = async () => {
+            try {
+                const res = await fetch(`${API_BASE_URL}/event-disabled-ticket-count/${event}`, {
+                    credentials: 'include'
+                });
+                if (res.ok) {
+                    const data = await res.json();
+                    setDisabledPurchased(Number(data.count) || 0);
+                } else {
+                    setDisabledPurchased(0);
+                }
+            } catch {
+                setDisabledPurchased(0);
+            }
+        };
+        load();
+    }, [loggedIn, event]);
 
 
     useEffect(() => {
@@ -114,6 +138,7 @@ export default function EventPage() {
     );
 
     const eventCounts = counts[event] || { regular: 0, disabled: 0 };
+    const disabledAlreadyBought = disabledPurchased > 0;
 
     useEffect(() => {
         if (categories.length === 0) return;
@@ -201,9 +226,11 @@ export default function EventPage() {
         }
 
         // Otherwise (new item OR disabled), do POST
-        if (isDisabledCatSelected && eventCounts.disabled >= 1) {
+        if (isDisabledCatSelected && (eventCounts.disabled >= 1 || disabledAlreadyBought)) {
             setLastClickedSection('disabled');
-            setErrorMessage('Es kann nur ein Behinderten-Ticket gebucht werden.');
+            setErrorMessage(disabledAlreadyBought ?
+                'Du hast bereits ein Behinderten-Ticket für dieses Event gekauft.' :
+                'Es kann nur ein Behinderten-Ticket gebucht werden.');
             setTimeout(() => setErrorMessage(''), 3000);
             return;
         }
@@ -411,7 +438,8 @@ export default function EventPage() {
                                 disabled={
                                     !isDisabledCatSelected ||
                                     Boolean(inCartItems[selectedCat]) ||
-                                    eventCounts.disabled >= 1
+                                    eventCounts.disabled >= 1 ||
+                                    disabledAlreadyBought
                                 }
                                 onClick={handleAddToCart}
                             >


### PR DESCRIPTION
## Summary
- add backend endpoint to check disabled tickets already bought for an event
- fetch that info on event page
- block purchasing additional disabled tickets when a prior order exists

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_687df60fd8148330bc96eaa329388484