### PR TITLE
Update routes to REST style

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,21 +197,21 @@ Die wichtigsten Routen des Express-Servers (siehe `server/server.js`) sind:
 
 | Methode | Pfad | Beschreibung |
 |---------|------|--------------|
-| `POST`  | `/register-user` | Registrierung eines neuen Nutzers inkl. optionaler Behindertenausweis-Daten |
-| `POST`  | `/login-user` | Benutzeranmeldung, legt Session-Cookie an |
-| `GET`   | `/session-status` | Prüft, ob ein Nutzer eingeloggt ist und liefert Profilinformationen |
-| `POST`  | `/logout` | Beendet die aktuelle Session |
-| `GET`   | `/user-address` | Liefert die hinterlegte Anschrift des eingeloggten Nutzers |
+| `POST`  | `/users` | Registrierung eines neuen Nutzers inkl. optionaler Behindertenausweis-Daten |
+| `POST`  | `/sessions` | Benutzeranmeldung, legt Session-Cookie an |
+| `GET`   | `/session` | Prüft, ob ein Nutzer eingeloggt ist und liefert Profilinformationen |
+| `DELETE` | `/session` | Beendet die aktuelle Session |
+| `GET`   | `/users/me/address` | Liefert die hinterlegte Anschrift des eingeloggten Nutzers |
 | `GET`   | `/disability-marks` | Auflistung möglicher Markierungen des Behindertenausweises |
-| `GET`   | `/pending-disability-requests` | Offene Anträge auf Nachteilsausgleich für den Service-Bereich |
-| `POST`  | `/disability-requests/:id/accept` | Antrag eines Nutzers akzeptieren |
-| `POST`  | `/disability-requests/:id/decline` | Antrag eines Nutzers ablehnen |
+| `GET`   | `/disability-requests/pending` | Offene Anträge auf Nachteilsausgleich für den Service-Bereich |
+| `PATCH` | `/disability-requests/:id/accepted` | Antrag eines Nutzers akzeptieren |
+| `PATCH` | `/disability-requests/:id/declined` | Antrag eines Nutzers ablehnen |
 | `GET`   | `/artists` | Auflistung aller Künstler |
-| `POST`  | `/create-artist` | Neuen Künstler anlegen |
-| `GET`   | `/tours-detailed` | Touren inkl. Events und Zugänglichkeitsdaten |
-| `POST`  | `/create-tour` | Neue Tour anlegen |
-| `GET`   | `/venues-detailed` | Liste aller Veranstaltungsorte mit Areas |
-| `POST`  | `/create-venue` | Neuen Veranstaltungsort anlegen |
+| `POST`  | `/artists` | Neuen Künstler anlegen |
+| `GET`   | `/tours/detailed` | Touren inkl. Events und Zugänglichkeitsdaten |
+| `POST`  | `/tours` | Neue Tour anlegen |
+| `GET`   | `/venues/detailed` | Liste aller Veranstaltungsorte mit Areas |
+| `POST`  | `/venues` | Neuen Veranstaltungsort anlegen |
 | `POST`  | `/cart-items` | Ticket zur Warenkorb-Session hinzufügen |
 | `GET`   | `/checkout` | Aktuellen Checkout laden |
 | `POST`  | `/orders` | Bestellung aus abgeschlossenem Checkout erzeugen |

--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -48,7 +48,7 @@ app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
 // Use memory storage for multer to get a Buffer for DB
 const upload = multer({ storage: multer.memoryStorage() });
-app.post('/upload-image', upload.single('image'), async (req, res) => {
+app.post('/images', upload.single('image'), async (req, res) => {
     const id = Number(req.body.id);
     const imageBuffer = req.file.buffer;
     const mimeType = req.file.mimetype;
@@ -65,7 +65,7 @@ app.post('/upload-image', upload.single('image'), async (req, res) => {
     }
 });
 
-app.get('/image/:id', async (req, res) => {
+app.get('/images/:id', async (req, res) => {
     try {
         const { rows } = await client.query(
             'SELECT image_data, image_type FROM images WHERE id = $1',
@@ -85,7 +85,7 @@ app.get('/image/:id', async (req, res) => {
 //     const multer = require('multer');
 //     const upload = multer({ storage: multer.memoryStorage() });
 
-app.post('/register-user', upload.fields([
+app.post('/users', upload.fields([
     { name: 'disabilityCardImageFront', maxCount: 1 },
     { name: 'disabilityCardImageBack', maxCount: 1 }
 ]), async (req, res) => {
@@ -263,7 +263,7 @@ app.post('/register-user', upload.fields([
     }
 });
 
-app.post('/login-user', async (req, res) => {
+app.post('/sessions', async (req, res) => {
     try {
         const { email, password } = req.body;
 
@@ -383,8 +383,8 @@ app.post('/login-user', async (req, res) => {
     }
 });
 
-// 4) GET /session-status – prüft, ob req.session.userId existiert
-app.get('/session-status', async (req, res) => {
+// 4) GET /session – prüft, ob req.session.userId existiert
+app.get('/session', async (req, res) => {
     if (!req.session.userId) {
         // Keine gültige Session → nicht eingeloggt
         return res.status(200).json({ loggedIn: false });
@@ -486,13 +486,13 @@ app.get('/session-status', async (req, res) => {
             },
         });
     } catch (err) {
-        console.error('Error in /session-status:', err);
+        console.error('Error in /session:', err);
         return res.status(500).json({ loggedIn: false });
     }
 });
 
-// 5) GET /logout – um die Session zu zerstören
-app.post('/logout', (req, res) => {
+// 5) DELETE /session – beendet die Session
+app.delete('/session', (req, res) => {
     req.session.destroy((err) => {
         if (err) {
             console.error('Session destroy error:', err);
@@ -505,7 +505,7 @@ app.post('/logout', (req, res) => {
 });
 
 // Liefert die in der Nutzertabelle hinterlegte Standardadresse
-app.get('/user-address', async (req, res) => {
+app.get('/users/me/address', async (req, res) => {
     if (!req.session.userId) {
         return res.status(401).json({ message: 'Not logged in' });
     }
@@ -527,7 +527,7 @@ app.get('/user-address', async (req, res) => {
 });
 
 // Liefert alle offenen Anträge auf Nachteilsausgleich
-app.get('/pending-disability-requests', async (req, res) => {
+app.get('/disability-requests/pending', async (req, res) => {
     try {
         const { rows } = await client.query(
             `SELECT user_id, visible_user_id, birth_date, updated_at
@@ -544,7 +544,7 @@ app.get('/pending-disability-requests', async (req, res) => {
 });
 
 // Liefert akzeptierte Anträge der letzten 30 Tage
-app.get('/accepted-disability-requests', async (req, res) => {
+app.get('/disability-requests/accepted', async (req, res) => {
     try {
         const { rows } = await client.query(
             `SELECT user_id, visible_user_id, birth_date, updated_at
@@ -734,7 +734,7 @@ app.patch(
 );
 
 // Accept a disability request
-app.post('/disability-requests/:id/accept', async (req, res) => {
+app.patch('/disability-requests/:id/accepted', async (req, res) => {
     const userId = req.params.id;
     try {
         await client.query(
@@ -752,7 +752,7 @@ app.post('/disability-requests/:id/accept', async (req, res) => {
 });
 
 // Decline a disability request
-app.post('/disability-requests/:id/decline', async (req, res) => {
+app.patch('/disability-requests/:id/declined', async (req, res) => {
     const userId = req.params.id;
     try {
         await client.query(
@@ -770,7 +770,7 @@ app.post('/disability-requests/:id/decline', async (req, res) => {
 });
 
 // Temporäres Speichern der Versandinformationen in der Session (wird später in der DB gespeichert)
-app.post('/checkout-shipping', (req, res) => {
+app.post('/checkout/shipping', (req, res) => {
     if (!req.session.userId) {
         return res.status(401).json({ message: 'Not logged in' });
     }
@@ -789,7 +789,7 @@ app.post('/checkout-shipping', (req, res) => {
 });
 
 // Liefert die aktuell in der Checkout-Session gespeicherten Lieferinformationen
-app.get('/checkout-shipping', (req, res) => {
+app.get('/checkout/shipping', (req, res) => {
     if (!req.session.userId) {
         return res.status(401).json({ message: 'Not logged in' });
     }
@@ -806,7 +806,7 @@ app.get('/checkout-shipping', (req, res) => {
     return res.json({ shippingInfo: req.session.checkout.shippingInfo || null });
 });
 // Temporäres Speichern der Zahlungsart in der Session
-app.post('/checkout-payment', (req, res) => {
+app.post('/checkout/payment', (req, res) => {
     if (!req.session.userId) {
         return res.status(401).json({ message: 'Not logged in' });
     }
@@ -825,7 +825,7 @@ app.post('/checkout-payment', (req, res) => {
 });
 
 // Liefert die aktuell gespeicherte Zahlungsart
-app.get('/checkout-payment', (req, res) => {
+app.get('/checkout/payment', (req, res) => {
     if (!req.session.userId) {
         return res.status(401).json({ message: 'Not logged in' });
     }
@@ -841,7 +841,7 @@ app.get('/checkout-payment', (req, res) => {
 
     return res.json({ paymentMethod: req.session.checkout.paymentMethod || null });
 });
-app.post('/create-country', async (req, res) => {
+app.post('/countries', async (req, res) => {
     try {
         const { name, code } = req.body;
         if (!name || !name.trim()) {
@@ -1429,7 +1429,7 @@ app.get('/shipping-options', async (req, res) => {
         res.status(500).json({ message: 'Serverfehler beim Laden der Versandoptionen' });
     }
 });
-app.post('/create-artist', upload.single('artistImage'), async (req, res) => {
+app.post('/artists', upload.single('artistImage'), async (req, res) => {
     try {
         const { name, biography, website } = req.body;
 
@@ -1473,7 +1473,7 @@ app.get('/artists', async (req, res) => {
     }
 });
 
-app.get('/artist-details/:id', async (req, res) => {
+app.get('/artists/:id', async (req, res) => {
     const artistId = req.params.id;
     try {
         const { rows } = await client.query(
@@ -1494,7 +1494,7 @@ app.get('/artist-details/:id', async (req, res) => {
         }
         return res.status(200).json({ artist: rows[0] });
     } catch (err) {
-        console.error('Error in /artist-details:', err);
+        console.error('Error in /artists/:id:', err);
         return res.status(500).json({ message: 'Fehler beim Laden des Künstlers' });
     }
 });
@@ -1536,7 +1536,7 @@ app.get('/subgenres', async (req, res) => {
         res.status(500).json({ message: 'Fehler beim Laden der Subgenres' });
     }
 });
-app.post('/create-tour', upload.single('tourImage'), async (req, res) => {
+app.post('/tours', upload.single('tourImage'), async (req, res) => {
     try {
         // 1) Aus dem Body lesen
         const {
@@ -1700,7 +1700,7 @@ app.post('/create-tour', upload.single('tourImage'), async (req, res) => {
     }
 });
 
-app.post('/create-city', express.json(), async (req, res) => {
+app.post('/cities', express.json(), async (req, res) => {
     try {
         const { name, countryId } = req.body;
         if (!name || !name.trim() || !countryId) {
@@ -1767,7 +1767,7 @@ app.get('/areas', async (req, res) => {
 });
 
 // POST: Venue erstellen (inkl. area capacities)
-app.post('/create-venue', upload.single('venueImage'), async (req, res) => {
+app.post('/venues', upload.single('venueImage'), async (req, res) => {
     const {
         name,
         address,
@@ -1881,7 +1881,7 @@ app.get('/venue-areas', async (req, res) => {
 });
 
 // GET: Detailed venues with city information
-app.get('/venues-detailed', async (req, res) => {
+app.get('/venues/detailed', async (req, res) => {
     try {
         const { rows } = await client.query(
             `SELECT v.id,
@@ -2054,7 +2054,7 @@ app.delete('/venues/:id', async (req, res) => {
         res.status(500).json({ message: 'Serverfehler beim Löschen des Venues' });
     }
 });
-app.post('/create-event', express.json(), async (req, res) => {
+app.post('/events', express.json(), async (req, res) => {
     const {
         tourId,
         venueId,
@@ -2175,7 +2175,7 @@ app.post('/create-event', express.json(), async (req, res) => {
     }
 });
 
-app.post('/create-genre', async (req, res) => {
+app.post('/genres', async (req, res) => {
     const { name, subgenres = [] } = req.body;
 
     if (!name || !name.trim()) {
@@ -2420,7 +2420,7 @@ app.get('/cities-with-venues', async (req, res) => {
     }
 });
 
-app.get("/tours-with-images", async (req, res) => {
+app.get("/tours/with-images", async (req, res) => {
     try {
         const { rows } = await client.query(
             `
@@ -2446,7 +2446,7 @@ app.get("/tours-with-images", async (req, res) => {
     }
 });
 
-app.get("/artists-with-images", async (req, res) => {
+app.get("/artists/with-images", async (req, res) => {
     try {
         const { rows } = await client.query(
             `
@@ -2520,7 +2520,7 @@ async function loadToursSearchCache() {
     toursSearchCache = { data: Object.values(map), timestamp: Date.now() };
 }
 
-app.get('/search-tours', async (req, res) => {
+app.get('/tours/search', async (req, res) => {
     const query = (req.query.q || '').toLowerCase();
     if (!toursSearchCache.data || Date.now() - toursSearchCache.timestamp > SEARCH_CACHE_TTL) {
         try {
@@ -2537,7 +2537,7 @@ app.get('/search-tours', async (req, res) => {
     res.json({ tours: result.slice(0, 10) });
 });
 
-app.post('/create-area', async (req, res) => {
+app.post('/areas', async (req, res) => {
     try {
         const { name, description } = req.body;
 
@@ -2717,7 +2717,7 @@ app.delete('/artists/:id', async (req, res) => {
 
 // server.js (vollständiger Endpoint)
 
-app.get('/tours-detailed', async (req, res) => {
+app.get('/tours/detailed', async (req, res) => {
     try {
         const marks = (req.query.marks || '')
             .split(',')
@@ -2941,7 +2941,7 @@ app.get('/tours-detailed', async (req, res) => {
         console.log('detailedTours insgesamt:', detailedTours);
         return res.status(200).json({ tours: detailedTours });
     } catch (err) {
-        console.error('Error in /tours-detailed:', err);
+        console.error('Error in /tours/detailed:', err);
         return res.status(500).json({ message: 'Fehler beim Laden der Touren' });
     }
 });
@@ -3244,7 +3244,7 @@ const mapMarkCodeToLabel = (mark_code) => {
 };
 
 // 2) Neuer Endpoint: Liefert pro Event einer Tour dessen Basis-Daten + accessibility-Labels
-app.get('/events-with-accessibility', async (req, res) => {
+app.get('/events/with-accessibility', async (req, res) => {
     const { tourId } = req.query;
     if (!tourId) {
         return res.status(400).json({ message: 'tourId als Query-Parameter ist erforderlich' });
@@ -3287,15 +3287,15 @@ app.get('/events-with-accessibility', async (req, res) => {
 
         return res.status(200).json({ events: result });
     } catch (error) {
-        console.error('Error in /events-with-accessibility:', error);
+        console.error('Error in /events/with-accessibility:', error);
         return res.status(500).json({ message: 'Serverfehler beim Laden der Events' });
     }
 });
 
-app.get('/event-accessibility', async (req, res) => {
-    const eventId = req.query.eventId;
+app.get('/events/:eventId/accessibility', async (req, res) => {
+    const eventId = req.params.eventId;
     if (!eventId) {
-        return res.status(400).json({ message: 'eventId als Query-Parameter ist erforderlich.' });
+        return res.status(400).json({ message: 'eventId als Parameter ist erforderlich.' });
     }
 
     try {
@@ -3317,13 +3317,13 @@ app.get('/event-accessibility', async (req, res) => {
 
         return res.status(200).json({ accessibilityLabels: uniqueLabels });
     } catch (err) {
-        console.error('Error in /event-accessibility:', err);
+        console.error('Error in /events/:eventId/accessibility:', err);
         return res.status(500).json({ message: 'Fehler beim Abrufen der Accessibility-Labels' });
     }
 });
 
 // Liefert Detailinformationen zu einer Tour inklusive aller Events
-app.get('/tour-details/:id', async (req, res) => {
+app.get('/tours/:id', async (req, res) => {
     const tourId = req.params.id;
     try {
         const { rows: tourRows } = await client.query(
@@ -3477,13 +3477,13 @@ app.get('/tour-details/:id', async (req, res) => {
             },
         });
     } catch (err) {
-        console.error('Error in /tour-details:', err);
+        console.error('Error in /tours/:id:', err);
         return res.status(500).json({ message: 'Fehler beim Laden der Tour' });
     }
 });
 
 // Liefert Detailinformationen zu einem Event inklusive Kategorien und zugehörigen Künstler-IDs
-app.get('/event-details/:id', async (req, res) => {
+app.get('/events/:id', async (req, res) => {
     const eventId = req.params.id;
     try {
         const { rows } = await client.query(
@@ -3545,7 +3545,7 @@ app.get('/event-details/:id', async (req, res) => {
 
         return res.status(200).json({ event, categories, artistIds });
     } catch (err) {
-        console.error('Error in /event-details:', err);
+        console.error('Error in /events/:id:', err);
         return res.status(500).json({ message: 'Fehler beim Laden des Events' });
     }
 });

--- a/eventim-disability-integration/src/components/ImageScroller.jsx
+++ b/eventim-disability-integration/src/components/ImageScroller.jsx
@@ -20,7 +20,7 @@ const ImageScroller = ({ tour }) => {
             for (const t of tour) {
                 if (!t.imageId || urls[t.imageId]) continue;
                 try {
-                    const res = await fetch(`http://localhost:4000/image/${t.imageId}`);
+                    const res = await fetch(`http://localhost:4000/images/${t.imageId}`);
                     if (!res.ok) continue;
                     const blob = await res.blob();
                     const objUrl = URL.createObjectURL(blob);

--- a/eventim-disability-integration/src/components/nav-bar.jsx
+++ b/eventim-disability-integration/src/components/nav-bar.jsx
@@ -44,7 +44,7 @@ export default function NavBar() {
         const timeout = setTimeout(async () => {
             try {
                 const res = await fetch(
-                    `${API_BASE_URL}/search-tours?q=${encodeURIComponent(q)}`,
+ `${API_BASE_URL}/tours/search?q=${encodeURIComponent(q)}`,
                     { signal: controller.signal }
                 );
                 if (res.ok) {
@@ -409,8 +409,8 @@ export default function NavBar() {
                                     type="button"
                                     className="login-button dropdown-logout"
                                     onClick={async () => {
-                                        await fetch(`${API_BASE_URL}/logout`, {
-                                            method: 'POST',
+                                        await fetch(`${API_BASE_URL}/session`, {
+                                            method: 'DELETE',
                                             credentials: 'include',
                                         });
                                         localStorage.removeItem('user');

--- a/eventim-disability-integration/src/components/smallArtistCard.jsx
+++ b/eventim-disability-integration/src/components/smallArtistCard.jsx
@@ -12,7 +12,7 @@ const SmallArtistCard = ({ imageId, title, link }) => {
         async function fetchImage() {
             if (!imageId) return;
             try {
-                const res = await fetch(`http://localhost:4000/image/${imageId}`);
+                const res = await fetch(`http://localhost:4000/images/${imageId}`);
                 if (!res.ok) {
                     console.warn(`Artist-Bild ${imageId} nicht gefunden`);
                     return;

--- a/eventim-disability-integration/src/components/smallTourCard.jsx
+++ b/eventim-disability-integration/src/components/smallTourCard.jsx
@@ -14,7 +14,7 @@ const SmallTourCard = ({ imageId, title, link }) => {
                 return;
             }
             try {
-                const res = await fetch(`http://localhost:4000/image/${imageId}`);
+                const res = await fetch(`http://localhost:4000/images/${imageId}`);
                 if (!res.ok) {
                     console.warn(`Tour-Bild ${imageId} nicht gefunden`);
                     setImageUrl(placeholderImage);

--- a/eventim-disability-integration/src/components/squareTourCard.jsx
+++ b/eventim-disability-integration/src/components/squareTourCard.jsx
@@ -13,7 +13,7 @@ const SquareTourCard = ({ imageId, title, bottomText, link }) => {
         async function fetchImage() {
             if (!imageId) return;
             try {
-                const res = await fetch(`http://localhost:4000/image/${imageId}`);
+                const res = await fetch(`http://localhost:4000/images/${imageId}`);
                 if (!res.ok) {
                     console.warn(`Tour-Bild ${imageId} nicht gefunden`);
                     return;

--- a/eventim-disability-integration/src/hooks/useAuth.js
+++ b/eventim-disability-integration/src/hooks/useAuth.js
@@ -46,7 +46,7 @@ export function useAuth() {
         // 2) Parallel die echte Session beim Server prüfen
         async function checkSession() {
             try {
-                const res = await fetch('http://localhost:4000/session-status', {
+                const res = await fetch('http://localhost:4000/session', {
                     method: 'GET',
                     credentials: 'include',
                 });

--- a/eventim-disability-integration/src/pages/admin/artists/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/artists/create.jsx
@@ -67,7 +67,7 @@ export default function ArtistCreation() {
             fd.append('website', formData.website);
             if (formData.artistImage) fd.append('artistImage', formData.artistImage);
 
-            const response = await fetch('http://localhost:4000/create-artist', {
+ const response = await fetch('http://localhost:4000/artists', {
                 method: 'POST',
                 body: fd,
             });

--- a/eventim-disability-integration/src/pages/admin/artists/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/artists/index.jsx
@@ -206,7 +206,7 @@ export default function ArtistsContent() {
                                         editedData.artist_image instanceof File
                                             ? URL.createObjectURL(editedData.artist_image)
                                             : artist.artist_image
-                                                ? `http://localhost:4000/image/${artist.artist_image}`
+                                                ? `http://localhost:4000/images/${artist.artist_image}`
                                                 : '/placeholder-artist.png'
                                     }
                                     alt={artist.name || 'Unbekannter Künstler'}

--- a/eventim-disability-integration/src/pages/admin/countries/cities/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/cities/create.jsx
@@ -43,7 +43,7 @@ export default function CityCreation() {
         }
 
         try {
-            const response = await fetch('http://localhost:4000/create-city', {
+          const response = await fetch('http://localhost:4000/cities', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(formData)

--- a/eventim-disability-integration/src/pages/admin/countries/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/create.jsx
@@ -40,7 +40,7 @@ export default function CountryCreation() {
         }
 
         try {
-            const response = await fetch('http://localhost:4000/create-country', {
+   const response = await fetch('http://localhost:4000/countries', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(formData),

--- a/eventim-disability-integration/src/pages/admin/genres/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/genres/create.jsx
@@ -53,7 +53,7 @@ export default function GenreCreation() {
 
         try {
             const payload = { ...formData, subgenres };
-            const res = await fetch('http://localhost:4000/create-genre', {
+const res = await fetch('http://localhost:4000/genres', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload),

--- a/eventim-disability-integration/src/pages/admin/tours/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/create.jsx
@@ -151,7 +151,7 @@ export default function TourCreation() {
         fd.append("genres", JSON.stringify(tourGenres));
 
         try {
-            const res = await fetch("http://localhost:4000/create-tour", {
+const res = await fetch("http://localhost:4000/tours", {
                 method: "POST",
                 body: fd,
             });

--- a/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
@@ -39,7 +39,7 @@ export default function EventCreation() {
     // 1) Load tours, venues, artists
     useEffect(() => {
         // wir brauchen start_date und end_date für Validierung
-        fetch('http://localhost:4000/tours-detailed')
+        fetch('http://localhost:4000/tours/detailed')
             .then(r => r.json())
             .then(d => setTours(d.tours));
 
@@ -293,7 +293,7 @@ export default function EventCreation() {
                 eventArtists,
                 categories: allCats
             };
-            const res = await fetch('http://localhost:4000/create-event', {
+       const res = await fetch('http://localhost:4000/events', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload)

--- a/eventim-disability-integration/src/pages/admin/tours/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/index.jsx
@@ -85,7 +85,7 @@ export default function ToursContent() {
     }, []);
     const fetchTours = async () => {
         try {
-            const res = await fetch(`${API_BASE_URL}/tours-detailed`);
+            const res = await fetch(`${API_BASE_URL}/tours/detailed`);
             if (!res.ok) throw new Error();
             const json = await res.json();
             const arr = Array.isArray(json.tours) ? json.tours : [];
@@ -227,7 +227,7 @@ export default function ToursContent() {
         // Event-Details laden
         try {
             const promises = (tour.events || []).map((ev) =>
-                fetch(`${API_BASE_URL}/event-details/${ev.id}`).then((r) =>
+                fetch(`${API_BASE_URL}/events/${ev.id}`).then((r) =>
                     r.ok ? r.json() : null
                 )
             );
@@ -447,7 +447,7 @@ export default function ToursContent() {
                                             editedData.tour_image instanceof File
                                                 ? URL.createObjectURL(editedData.tour_image)
                                                 : tour.tour_image
-                                                    ? `${API_BASE_URL}/image/${tour.tour_image}`
+                                                    ? `${API_BASE_URL}/images/${tour.tour_image}`
                                                     : '/placeholder-tour.png'
                                         }
                                         alt={tour.title || 'Unbekannte Tour'}

--- a/eventim-disability-integration/src/pages/admin/venues/areas/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/areas/create.jsx
@@ -34,7 +34,7 @@ export default function AreaCreation() {
         }
 
         try {
-            const res = await fetch('http://localhost:4000/create-area', {
+      const res = await fetch('http://localhost:4000/areas', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(formData)

--- a/eventim-disability-integration/src/pages/admin/venues/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/create.jsx
@@ -101,7 +101,7 @@ export default function VenueCreation() {
             fd.append('venueAreas', JSON.stringify(venueAreas));
             if (formData.venueImage) fd.append('venueImage', formData.venueImage);
 
-            const res = await fetch('http://localhost:4000/create-venue', {
+ const res = await fetch('http://localhost:4000/venues', {
                 method: 'POST',
                 body: fd,
             });

--- a/eventim-disability-integration/src/pages/admin/venues/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/index.jsx
@@ -44,7 +44,7 @@ export default function VenuesContent() {
 
     const fetchVenues = async () => {
         try {
-            const res = await fetch('http://localhost:4000/venues-detailed');
+            const res = await fetch('http://localhost:4000/venues/detailed');
             const json = await res.json();
             const arr = Array.isArray(json.venues) ? json.venues : [];
             setVenues(arr);
@@ -271,7 +271,7 @@ export default function VenuesContent() {
                                         editedData.venue_image instanceof File
                                             ? URL.createObjectURL(editedData.venue_image)
                                             : venue.venue_image
-                                                ? `http://localhost:4000/image/${venue.venue_image}`
+                                                ? `http://localhost:4000/images/${venue.venue_image}`
                                                 : '/pictures/placeholder.png'
                                     }
                                     alt={venue.name || 'Unbekanntes Venue'}

--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
@@ -92,7 +92,7 @@ export default function EventPage() {
         if (!artist || !tour || !event) return;
         const load = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/event-details/${event}`);
+                const res = await fetch(`${API_BASE_URL}/events/${event}`);
                 if (!res.ok) throw new Error('Fetch failed');
                 const data = await res.json();
 
@@ -336,7 +336,7 @@ export default function EventPage() {
                     <img
                         src={
                             eventData.tourImage
-                                ? `${API_BASE_URL}/image/${eventData.tourImage}`
+                                ? `${API_BASE_URL}/images/${eventData.tourImage}`
                                 : '/pictures/placeholder.png'
                         }
                         alt={eventData.tourTitle || 'Event'}

--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/index.jsx
@@ -27,7 +27,7 @@ export default function TourEventsPage() {
         if (!tour) return;
         const load = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/tour-details/${tour}`);
+              const res = await fetch(`${API_BASE_URL}/tours/${tour}`);
                 if (!res.ok) throw new Error();
                 const data = await res.json();
                 setTourData(data.tour);
@@ -98,7 +98,7 @@ export default function TourEventsPage() {
                     <img
                         src={
                             tourData.tour_image
-                                ? `${API_BASE_URL}/image/${tourData.tour_image}`
+                                ? `${API_BASE_URL}/images/${tourData.tour_image}`
                                 : '/pictures/placeholder.png'
                         }
                         alt={tourData.title || 'Tour'}

--- a/eventim-disability-integration/src/pages/artists/[artist]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/index.jsx
@@ -39,7 +39,7 @@ export default function ArtistPage() {
         if (!artist) return;
         const loadArtist = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/artist-details/${artist}`);
+       const res = await fetch(`${API_BASE_URL}/artists/${artist}`);
                 if (!res.ok) throw new Error();
                 const data = await res.json();
                 setArtistData(data.artist);
@@ -54,7 +54,7 @@ export default function ArtistPage() {
     useEffect(() => {
         const fetchTours = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/tours-detailed`);
+                const res = await fetch(`${API_BASE_URL}/tours/detailed`);
                 if (!res.ok) throw new Error();
                 const json = await res.json();
                 const arr = Array.isArray(json.tours) ? json.tours : [];
@@ -149,7 +149,7 @@ export default function ArtistPage() {
     if (!artistData) return <div>Loading …</div>;
 
     const artistImage = artistData.artist_image
-        ? `${API_BASE_URL}/image/${artistData.artist_image}`
+        ? `${API_BASE_URL}/images/${artistData.artist_image}`
         : '/pictures/placeholder.png';
 
     const totalEventCount = filteredTours.reduce((total, tour) => total + tour.eventCount, 0);
@@ -175,7 +175,7 @@ export default function ArtistPage() {
                     <img
                         src={
                             artistData.artist_image
-                                ? `${API_BASE_URL}/image/${artistData.artist_image}`
+                                ? `${API_BASE_URL}/images/${artistData.artist_image}`
                                 : '/pictures/placeholder.png'
                         }
                         alt={artistData.name || 'Artist'}
@@ -228,7 +228,7 @@ export default function ArtistPage() {
                                             className="artist-image"
                                             src={
                                                 tour.tour_image
-                                                    ? `${API_BASE_URL}/image/${tour.tour_image}`
+                                                    ? `${API_BASE_URL}/images/${tour.tour_image}`
                                                     : '/pictures/placeholder.png'
                                             }
                                             alt={tour.title || 'Unbekannte Tour'}

--- a/eventim-disability-integration/src/pages/checkout/payment.jsx
+++ b/eventim-disability-integration/src/pages/checkout/payment.jsx
@@ -66,7 +66,7 @@ export default function Payment() {
     // After shipping options loaded, load selection from session
     useEffect(() => {
         if (!shippingOptions.length) return;
-        fetch(`${API_BASE_URL}/checkout-shipping`, { credentials: "include" })
+        fetch(`${API_BASE_URL}/checkout/shipping`, { credentials: "include" })
             .then((res) => (res.ok ? res.json() : null))
             .then((data) => {
                 if (data && data.shippingInfo && data.shippingInfo.shippingMethod) {
@@ -82,7 +82,7 @@ export default function Payment() {
     // After payment options loaded, check if session stored a method
     useEffect(() => {
         if (!paymentOptions.length) return;
-        fetch(`${API_BASE_URL}/checkout-payment`, { credentials: "include" })
+        fetch(`${API_BASE_URL}/checkout/payment`, { credentials: "include" })
             .then((res) => (res.ok ? res.json() : null))
             .then((data) => {
                 if (data && data.paymentMethod) {
@@ -96,7 +96,7 @@ export default function Payment() {
     // Persist selection in session whenever it changes
     useEffect(() => {
         if (!selectedPayment) return;
-        fetch(`${API_BASE_URL}/checkout-payment`, {
+        fetch(`${API_BASE_URL}/checkout/payment`, {
             method: "POST",
             credentials: "include",
             headers: { "Content-Type": "application/json" },
@@ -171,7 +171,7 @@ export default function Payment() {
     const handleSubmit = async () => {
         if (!selectedPayment) return;
         try {
-            await fetch(`${API_BASE_URL}/checkout-payment`, {
+            await fetch(`${API_BASE_URL}/checkout/payment`, {
                 method: "POST",
                 credentials: "include",
                 headers: { "Content-Type": "application/json" },

--- a/eventim-disability-integration/src/pages/checkout/shipping-information.jsx
+++ b/eventim-disability-integration/src/pages/checkout/shipping-information.jsx
@@ -34,7 +34,7 @@ export default function ShippingInformation() {
     // Fetch user data
     const fetchAddress = async () => {
         try {
-            const res = await fetch(`${API_BASE_URL}/user-address`, { credentials: 'include' });
+          const res = await fetch(`${API_BASE_URL}/users/me/address`, { credentials: 'include' });
             if (res.ok) {
                 const data = await res.json();
                 if (data.address) {
@@ -75,7 +75,7 @@ export default function ShippingInformation() {
 
     const fetchSessionShipping = async () => {
         try {
-            const res = await fetch(`${API_BASE_URL}/checkout-shipping`, { credentials: 'include' });
+            const res = await fetch(`${API_BASE_URL}/checkout/shipping`, { credentials: 'include' });
             if (res.ok) {
                 const data = await res.json();
                 if (data.shippingInfo) {
@@ -166,7 +166,7 @@ export default function ShippingInformation() {
 
     // persist changes in session
     useEffect(() => {
-        fetch(`${API_BASE_URL}/checkout-shipping`, {
+        fetch(`${API_BASE_URL}/checkout/shipping`, {
             method: 'POST',
             credentials: 'include',
             headers: { 'Content-Type': 'application/json' },
@@ -176,7 +176,7 @@ export default function ShippingInformation() {
 
     const handleSubmit = async () => {
         try {
-            await fetch(`${API_BASE_URL}/checkout-shipping`, {
+            await fetch(`${API_BASE_URL}/checkout/shipping`, {
                 method: 'POST',
                 credentials: 'include',
                 headers: { 'Content-Type': 'application/json' },

--- a/eventim-disability-integration/src/pages/checkout/shopping-cart.jsx
+++ b/eventim-disability-integration/src/pages/checkout/shopping-cart.jsx
@@ -166,7 +166,7 @@ export default function Checkout() {
                                 <img
                                     src={
                                         image
-                                            ? `${API_BASE_URL}/image/${image}`
+                                            ? `${API_BASE_URL}/images/${image}`
                                             : '/images/placeholder.jpg'
                                     }
                                     alt={eventTitle}

--- a/eventim-disability-integration/src/pages/genres/[genre]/[subgenre]/index.jsx
+++ b/eventim-disability-integration/src/pages/genres/[genre]/[subgenre]/index.jsx
@@ -26,7 +26,7 @@ export default function SubgenreEventsPage() {
                 if (!sg) throw new Error();
                 setSubgenreData({ id: sg.id, name: sg.name, genreName: g.name });
 
-                const toursRes = await fetch(`${API_BASE_URL}/tours-detailed`);
+                const toursRes = await fetch(`${API_BASE_URL}/tours/detailed`);
                 if (!toursRes.ok) throw new Error();
                 const toursJson = await toursRes.json();
                 const tours = Array.isArray(toursJson.tours) ? toursJson.tours : [];

--- a/eventim-disability-integration/src/pages/genres/[genre]/index.jsx
+++ b/eventim-disability-integration/src/pages/genres/[genre]/index.jsx
@@ -51,7 +51,7 @@ export default function GenrePage() {
     useEffect(() => {
         const fetchTours = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/tours-detailed`);
+                const res = await fetch(`${API_BASE_URL}/tours/detailed`);
                 if (!res.ok) throw new Error();
                 const json = await res.json();
                 setTours(Array.isArray(json.tours) ? json.tours : []);
@@ -296,7 +296,7 @@ export default function GenrePage() {
                                                             <img
                                                                 src={
                                                                     ev.tourImage
-                                                                        ? `${API_BASE_URL}/image/${ev.tourImage}`
+                                                                        ? `${API_BASE_URL}/images/${ev.tourImage}`
                                                                         : '/pictures/placeholder.png'
                                                                 }
                                                                 alt={ev.tourTitle || 'Tour'}

--- a/eventim-disability-integration/src/pages/index.jsx
+++ b/eventim-disability-integration/src/pages/index.jsx
@@ -14,7 +14,7 @@ export default function HomePage() {
     useEffect(() => {
         async function fetchTours() {
             try {
-                const res = await fetch("http://localhost:4000/tours-with-images");
+                const res = await fetch("http://localhost:4000/tours/with-images");
                 if (!res.ok) throw new Error("Failed to load tours");
                 const body = await res.json();
                 setTours(body.tours);
@@ -30,7 +30,7 @@ export default function HomePage() {
     useEffect(() => {
         async function fetchArtists() {
             try {
-                const res = await fetch("http://localhost:4000/artists-with-images");
+                const res = await fetch("http://localhost:4000/artists/with-images");
                 if (!res.ok) throw new Error("Failed to load artists");
                 const body = await res.json();
                 setArtists(body.artists);

--- a/eventim-disability-integration/src/pages/locations/[city]/[venue]/index.jsx
+++ b/eventim-disability-integration/src/pages/locations/[city]/[venue]/index.jsx
@@ -25,7 +25,7 @@ export default function VenueEventsPage() {
                 if (!c || !v) throw new Error();
                 setVenueData({ id: v.id, name: v.name, cityName: c.name });
 
-                const toursRes = await fetch(`${API_BASE_URL}/tours-detailed`);
+                const toursRes = await fetch(`${API_BASE_URL}/tours/detailed`);
                 if (!toursRes.ok) throw new Error();
                 const toursJson = await toursRes.json();
                 const tours = Array.isArray(toursJson.tours) ? toursJson.tours : [];
@@ -150,7 +150,7 @@ export default function VenueEventsPage() {
                                                 className="artist-image"
                                                 src={
                                                     ev.tourImage
-                                                        ? `${API_BASE_URL}/image/${ev.tourImage}`
+                                                        ? `${API_BASE_URL}/images/${ev.tourImage}`
                                                         : '/pictures/placeholder.png'
                                                 }
                                                 alt={ev.tourTitle || 'Tour'}

--- a/eventim-disability-integration/src/pages/locations/[city]/index.jsx
+++ b/eventim-disability-integration/src/pages/locations/[city]/index.jsx
@@ -48,7 +48,7 @@ export default function CityPage() {
     useEffect(() => {
         const fetchTours = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/tours-detailed`);
+                const res = await fetch(`${API_BASE_URL}/tours/detailed`);
                 if (!res.ok) throw new Error();
                 const json = await res.json();
                 setTours(Array.isArray(json.tours) ? json.tours : []);
@@ -210,7 +210,7 @@ export default function CityPage() {
                                             className="artist-image"
                                             src={
                                                 sg.image
-                                                    ? `${API_BASE_URL}/image/${sg.image}`
+                                                    ? `${API_BASE_URL}/images/${sg.image}`
                                                     : '/pictures/placeholder.png'
                                             }
                                             alt={sg.title}
@@ -281,7 +281,7 @@ export default function CityPage() {
                                                             {/*    <img*/}
                                                             {/*        src={*/}
                                                             {/*            ev.tourImage*/}
-                                                            {/*                ? `${API_BASE_URL}/image/${ev.tourImage}`*/}
+                                                            {/*                ? `${API_BASE_URL}/images/${ev.tourImage}`*/}
                                                             {/*                : '/pictures/placeholder.png'*/}
                                                             {/*        }*/}
                                                             {/*        alt={ev.tourTitle || 'Tour'}*/}
@@ -307,7 +307,7 @@ export default function CityPage() {
                                                             <img
                                                                 src={
                                                                     ev.tourImage
-                                                                        ? `${API_BASE_URL}/image/${ev.tourImage}`
+                                                                        ? `${API_BASE_URL}/images/${ev.tourImage}`
                                                                         : '/pictures/placeholder.png'
                                                                 }
                                                                 alt={ev.tourTitle || 'Tour'}

--- a/eventim-disability-integration/src/pages/login.jsx
+++ b/eventim-disability-integration/src/pages/login.jsx
@@ -76,7 +76,7 @@ export default function LoginPage() {
         }
 
         try {
-            const res = await fetch('http://localhost:4000/login-user', {
+            const res = await fetch('http://localhost:4000/sessions', {
                 method: 'POST',
                 credentials: 'include',              // ← Cookie einschließen
                 headers: { 'Content-Type': 'application/json' },

--- a/eventim-disability-integration/src/pages/profile/index.jsx
+++ b/eventim-disability-integration/src/pages/profile/index.jsx
@@ -12,7 +12,7 @@ import { useValidation } from "../../hooks/useValidation";
 export async function getServerSideProps({ req }) {
     const cookie = req.headers.cookie || "";
     try {
-        const res = await fetch(`${API_BASE_URL}/session-status`, {
+        const res = await fetch(`${API_BASE_URL}/session`, {
             headers: { cookie },
         });
         const data = await res.json();
@@ -162,7 +162,7 @@ export default function ProfilePage() {
             const query = marks && marks.length > 0
                 ? `?marks=${encodeURIComponent(marks.join(','))}`
                 : '';
-            const res = await fetch(`${API_BASE_URL}/tours-detailed${query}`);
+            const res = await fetch(`${API_BASE_URL}/tours/detailed${query}`);
             if (res.ok) {
                 const data = await res.json();
                 setTours(Array.isArray(data.tours) ? data.tours : []);
@@ -192,8 +192,8 @@ export default function ProfilePage() {
     const fetchProfileData = async () => {
         try {
             const [sessionRes, addrRes] = await Promise.all([
-                fetch(`${API_BASE_URL}/session-status`, { credentials: 'include' }),
-                fetch(`${API_BASE_URL}/user-address`,   { credentials: 'include' })
+                fetch(`${API_BASE_URL}/session`, { credentials: 'include' }),
+                fetch(`${API_BASE_URL}/users/me/address`,   { credentials: 'include' })
             ]);
 
             if (sessionRes.ok) {

--- a/eventim-disability-integration/src/pages/registration.jsx
+++ b/eventim-disability-integration/src/pages/registration.jsx
@@ -208,7 +208,7 @@ export default function Registration() {
             // (Server will parse JSON.parse(req.body.disabilityMarks))
             payload.append('disabilityMarks', JSON.stringify(selectedMarks));
 
-            const response = await fetch('http://localhost:4000/register-user', {
+            const response = await fetch('http://localhost:4000/users', {
                 method: 'POST',
                 body: payload,
             });

--- a/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
+++ b/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
@@ -20,7 +20,7 @@ export default function CompensationRequests() {
 
     const fetchPending = async () => {
         try {
-            const r = await fetch(`${API_BASE_URL}/pending-disability-requests`);
+            const r = await fetch(`${API_BASE_URL}/disability-requests/pending`);
             if (r.ok) {
                 const js = await r.json();
                 setRequests(Array.isArray(js.requests) ? js.requests : []);
@@ -32,7 +32,7 @@ export default function CompensationRequests() {
 
     const fetchAccepted = async () => {
         try {
-            const r = await fetch(`${API_BASE_URL}/accepted-disability-requests`);
+            const r = await fetch(`${API_BASE_URL}/disability-requests/accepted`);
             if (r.ok) {
                 const js = await r.json();
                 setAcceptedRequests(Array.isArray(js.requests) ? js.requests : []);
@@ -61,14 +61,14 @@ export default function CompensationRequests() {
             });
 
             if (js.disabilityData?.disability_card_image_front) {
-                const fr = await fetch(`${API_BASE_URL}/image/${js.disabilityData.disability_card_image_front}`);
+                const fr = await fetch(`${API_BASE_URL}/images/${js.disabilityData.disability_card_image_front}`);
                 if (fr.ok) {
                     const blob = await fr.blob();
                     setImgFrontUrl(URL.createObjectURL(blob));
                 }
             }
             if (js.disabilityData?.disability_card_image_back) {
-                const br = await fetch(`${API_BASE_URL}/image/${js.disabilityData.disability_card_image_back}`);
+                const br = await fetch(`${API_BASE_URL}/images/${js.disabilityData.disability_card_image_back}`);
                 if (br.ok) {
                     const blob = await br.blob();
                     setImgBackUrl(URL.createObjectURL(blob));
@@ -91,7 +91,7 @@ export default function CompensationRequests() {
     const acceptRequest = async () => {
         if (!selectedUser) return;
         try {
-            await fetch(`${API_BASE_URL}/disability-requests/${selectedUser.user_id}/accept`, { method: 'POST' });
+            await fetch(`${API_BASE_URL}/disability-requests/${selectedUser.user_id}/accepted`, { method: 'PATCH' });
         } catch (err) {
             console.error('Error accepting request:', err);
         }
@@ -102,7 +102,7 @@ export default function CompensationRequests() {
     const declineRequest = async () => {
         if (!selectedUser) return;
         try {
-            await fetch(`${API_BASE_URL}/disability-requests/${selectedUser.user_id}/decline`, { method: 'POST' });
+            await fetch(`${API_BASE_URL}/disability-requests/${selectedUser.user_id}/declined`, { method: 'PATCH' });
         } catch (err) {
             console.error('Error declining request:', err);
         }


### PR DESCRIPTION
## Summary
- rename many Express routes for REST compliance
- update README API table
- update frontend fetch calls accordingly

## Testing
- `npm test -- -w 0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882991fe28c8330a591cd8c99166800