### PR TITLE
Add credentials include to all backend API calls

### DIFF
--- a/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
+++ b/eventim-disability-integration/src/components/DisabilityRequestModal.jsx
@@ -51,7 +51,9 @@ export default function DisabilityRequestModal({
 
     useEffect(() => {
         if (editMode) {
-            fetch(`${API_BASE_URL}/disability-marks`)
+            fetch(`${API_BASE_URL}/disability-marks`, {
+                credentials: 'include',
+            })
                 .then((r) => r.ok ? r.json() : { marks: [] })
                 .then((js) => setMarksOptions(Array.isArray(js.marks) ? js.marks : []))
                 .catch((err) => console.error('Error loading marks:', err));

--- a/eventim-disability-integration/src/components/ImageScroller.jsx
+++ b/eventim-disability-integration/src/components/ImageScroller.jsx
@@ -20,7 +20,9 @@ const ImageScroller = ({ tour }) => {
             for (const t of tour) {
                 if (!t.imageId || urls[t.imageId]) continue;
                 try {
-                    const res = await fetch(`http://localhost:4000/image/${t.imageId}`);
+                    const res = await fetch(`http://localhost:4000/image/${t.imageId}`, {
+                        credentials: "include",
+                    });
                     if (!res.ok) continue;
                     const blob = await res.blob();
                     const objUrl = URL.createObjectURL(blob);

--- a/eventim-disability-integration/src/components/nav-bar.jsx
+++ b/eventim-disability-integration/src/components/nav-bar.jsx
@@ -45,7 +45,7 @@ export default function NavBar() {
             try {
                 const res = await fetch(
                     `${API_BASE_URL}/search-tours?q=${encodeURIComponent(q)}`,
-                    { signal: controller.signal }
+                    { signal: controller.signal, credentials: 'include' }
                 );
                 if (res.ok) {
                     const data = await res.json();

--- a/eventim-disability-integration/src/components/smallArtistCard.jsx
+++ b/eventim-disability-integration/src/components/smallArtistCard.jsx
@@ -12,7 +12,9 @@ const SmallArtistCard = ({ imageId, title, link }) => {
         async function fetchImage() {
             if (!imageId) return;
             try {
-                const res = await fetch(`http://localhost:4000/image/${imageId}`);
+                const res = await fetch(`http://localhost:4000/image/${imageId}`, {
+                    credentials: "include",
+                });
                 if (!res.ok) {
                     console.warn(`Artist-Bild ${imageId} nicht gefunden`);
                     return;

--- a/eventim-disability-integration/src/components/smallTourCard.jsx
+++ b/eventim-disability-integration/src/components/smallTourCard.jsx
@@ -14,7 +14,9 @@ const SmallTourCard = ({ imageId, title, link }) => {
                 return;
             }
             try {
-                const res = await fetch(`http://localhost:4000/image/${imageId}`);
+                const res = await fetch(`http://localhost:4000/image/${imageId}`, {
+                    credentials: "include",
+                });
                 if (!res.ok) {
                     console.warn(`Tour-Bild ${imageId} nicht gefunden`);
                     setImageUrl(placeholderImage);

--- a/eventim-disability-integration/src/components/squareTourCard.jsx
+++ b/eventim-disability-integration/src/components/squareTourCard.jsx
@@ -13,7 +13,9 @@ const SquareTourCard = ({ imageId, title, bottomText, link }) => {
         async function fetchImage() {
             if (!imageId) return;
             try {
-                const res = await fetch(`http://localhost:4000/image/${imageId}`);
+                const res = await fetch(`http://localhost:4000/image/${imageId}`, {
+                    credentials: "include",
+                });
                 if (!res.ok) {
                     console.warn(`Tour-Bild ${imageId} nicht gefunden`);
                     return;

--- a/eventim-disability-integration/src/pages/admin/artists/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/artists/create.jsx
@@ -21,7 +21,7 @@ export default function ArtistCreation() {
     const validation = useValidation({ name: '', website: '' });
 
     useEffect(() => {
-        fetch('http://localhost:4000/countries')
+        fetch('http://localhost:4000/countries', { credentials: 'include' })
             .then(res => res.json())
             .then(data => setCountries(data.countries))
             .catch(err => console.error('Fehler beim Laden der Länder:', err));
@@ -70,6 +70,7 @@ export default function ArtistCreation() {
             const response = await fetch('http://localhost:4000/create-artist', {
                 method: 'POST',
                 body: fd,
+                credentials: 'include',
             });
             const data = await response.json();
 

--- a/eventim-disability-integration/src/pages/admin/artists/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/artists/index.jsx
@@ -37,7 +37,7 @@ export default function ArtistsContent() {
 
     const fetchArtists = async () => {
         try {
-            const res = await fetch('http://localhost:4000/artists');
+            const res = await fetch('http://localhost:4000/artists', { credentials: 'include' });
             const json = await res.json();
             const dataArray = Array.isArray(json)
                 ? json
@@ -93,6 +93,7 @@ export default function ArtistsContent() {
                 {
                     method: 'PUT',
                     body: formData,
+                    credentials: 'include',
                 }
             );
             if (!response.ok) {
@@ -110,6 +111,7 @@ export default function ArtistsContent() {
         try {
             const response = await fetch(`http://localhost:4000/artists/${id}`, {
                 method: 'DELETE',
+                credentials: 'include',
             });
             if (!response.ok) {
                 const d = await response.json().catch(() => ({}));

--- a/eventim-disability-integration/src/pages/admin/countries/cities/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/cities/create.jsx
@@ -18,7 +18,7 @@ export default function CityCreation() {
 
     useEffect(() => {
         // Länder für Dropdown laden
-        fetch('http://localhost:4000/countries')
+        fetch('http://localhost:4000/countries', { credentials: 'include' })
             .then(res => res.json())
             .then(data => setCountries(data.countries))
             .catch(err => console.error('Fehler beim Laden der Länder:', err));
@@ -46,7 +46,8 @@ export default function CityCreation() {
             const response = await fetch('http://localhost:4000/create-city', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(formData)
+                body: JSON.stringify(formData),
+                credentials: 'include',
             });
             const data = await response.json();
 

--- a/eventim-disability-integration/src/pages/admin/countries/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/create.jsx
@@ -44,6 +44,7 @@ export default function CountryCreation() {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(formData),
+                credentials: 'include',
             });
             const data = await response.json();
 

--- a/eventim-disability-integration/src/pages/admin/countries/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/countries/index.jsx
@@ -31,7 +31,9 @@ export default function CountriesContent() {
 
     const fetchCountries = async () => {
         try {
-            const res = await fetch(`${API_BASE_URL}/countries-with-cities`);
+            const res = await fetch(`${API_BASE_URL}/countries-with-cities`, {
+                credentials: 'include',
+            });
             if (!res.ok) throw new Error();
             const j = await res.json();
             const arr = Array.isArray(j.countries) ? j.countries : [];
@@ -93,6 +95,7 @@ export default function CountriesContent() {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload),
+                credentials: 'include',
             });
             if (!response.ok) setDeleteError('Fehler beim Löschen da Städte dieses Landes in einem Stadion verwendet werden');
             setEditingId(null);
@@ -106,6 +109,7 @@ export default function CountriesContent() {
         try {
             const res = await fetch(`${API_BASE_URL}/countries/${id}`, {
                 method: 'DELETE',
+                credentials: 'include',
             });
             if (!res.ok) {
                 const errorData = await res.json();

--- a/eventim-disability-integration/src/pages/admin/genres/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/genres/create.jsx
@@ -57,6 +57,7 @@ export default function GenreCreation() {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload),
+                credentials: 'include',
             });
             const data = await res.json();
 

--- a/eventim-disability-integration/src/pages/admin/genres/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/genres/index.jsx
@@ -35,7 +35,9 @@ export default function GenresContent() {
 
     const fetchGenres = async () => {
         try {
-            const res = await fetch(`${API_BASE_URL}/genres-with-subgenres`);
+            const res = await fetch(`${API_BASE_URL}/genres-with-subgenres`, {
+                credentials: 'include',
+            });
             if (!res.ok) throw new Error();
             const j = await res.json();
             const arr = Array.isArray(j.genres) ? j.genres : [];
@@ -92,6 +94,7 @@ export default function GenresContent() {
                 method: 'PUT',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload),
+                credentials: 'include',
             });
             if (!response.ok) setDeleteError('Fehler beim Löschen des Sub-Genres. Möglicherweise ist dieses Sub-Genre mit einer Tour verbunden.');;
             setEditingId(null);
@@ -103,7 +106,7 @@ export default function GenresContent() {
 
     const handleDelete = async (id) => {
         try {
-            const res = await fetch(`${API_BASE_URL}/genres/${id}`, { method: 'DELETE' });
+            const res = await fetch(`${API_BASE_URL}/genres/${id}`, { method: 'DELETE', credentials: 'include' });
             if (!res.ok) {
                 const errorData = await res.json();
                 setDeleteError('Fehler beim Löschen des Genres. Möglicherweise ist dieses Genre mit einer Tour verbunden.');

--- a/eventim-disability-integration/src/pages/admin/tours/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/create.jsx
@@ -29,12 +29,12 @@ export default function TourCreation() {
     const validation = useValidation({ title: '', startDate: '', endDate: '' });
 
     useEffect(() => {
-        fetch("http://localhost:4000/artists")
+        fetch("http://localhost:4000/artists", { credentials: 'include' })
             .then((res) => res.json())
             .then((data) => setArtists(data.artists))
             .catch((err) => console.error("Fehler beim Laden der Künstler:", err));
 
-        fetch("http://localhost:4000/genres")
+        fetch("http://localhost:4000/genres", { credentials: 'include' })
             .then((res) => res.json())
             .then((data) => setGenres(data.genres))
             .catch((err) => console.error("Fehler beim Laden der Genres:", err));
@@ -67,7 +67,9 @@ export default function TourCreation() {
         );
         if (gid && !subgenresByGenre[gid]) {
             try {
-                const res = await fetch(`http://localhost:4000/subgenres?genreId=${gid}`);
+                const res = await fetch(`http://localhost:4000/subgenres?genreId=${gid}`, {
+                    credentials: 'include',
+                });
                 const data = await res.json();
                 setSubgenresByGenre((p) => ({ ...p, [gid]: data.subgenres }));
             } catch (err) {
@@ -154,6 +156,7 @@ export default function TourCreation() {
             const res = await fetch("http://localhost:4000/create-tour", {
                 method: "POST",
                 body: fd,
+                credentials: 'include',
             });
             const data = await res.json();
             if (res.ok) {

--- a/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/events/create.jsx
@@ -39,15 +39,15 @@ export default function EventCreation() {
     // 1) Load tours, venues, artists
     useEffect(() => {
         // wir brauchen start_date und end_date für Validierung
-        fetch('http://localhost:4000/tours-detailed')
+        fetch('http://localhost:4000/tours-detailed', { credentials: 'include' })
             .then(r => r.json())
             .then(d => setTours(d.tours));
 
-        fetch('http://localhost:4000/venues')
+        fetch('http://localhost:4000/venues', { credentials: 'include' })
             .then(r => r.json())
             .then(d => setVenues(d.venues));
 
-        fetch('http://localhost:4000/artists')
+        fetch('http://localhost:4000/artists', { credentials: 'include' })
             .then(r => r.json())
             .then(d => setArtists(d.artists));
     }, []);
@@ -60,7 +60,7 @@ export default function EventCreation() {
             setDisabilityCapacityMap({});
             return;
         }
-        fetch(`http://localhost:4000/venue-areas?venueId=${formData.venueId}`)
+        fetch(`http://localhost:4000/venue-areas?venueId=${formData.venueId}`, { credentials: 'include' })
             .then(r => r.json())
             .then(d => {
                 const allAreas = d.venueAreas || [];
@@ -296,7 +296,8 @@ export default function EventCreation() {
             const res = await fetch('http://localhost:4000/create-event', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(payload)
+                body: JSON.stringify(payload),
+                credentials: 'include',
             });
             const data = await res.json();
             if (res.ok) {

--- a/eventim-disability-integration/src/pages/admin/tours/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/tours/index.jsx
@@ -85,7 +85,9 @@ export default function ToursContent() {
     }, []);
     const fetchTours = async () => {
         try {
-            const res = await fetch(`${API_BASE_URL}/tours-detailed`);
+            const res = await fetch(`${API_BASE_URL}/tours-detailed`, {
+                credentials: 'include',
+            });
             if (!res.ok) throw new Error();
             const json = await res.json();
             const arr = Array.isArray(json.tours) ? json.tours : [];
@@ -98,7 +100,9 @@ export default function ToursContent() {
     };
     const fetchAllArtists = async () => {
         try {
-            const res = await fetch(`${API_BASE_URL}/artists`);
+            const res = await fetch(`${API_BASE_URL}/artists`, {
+                credentials: 'include',
+            });
             if (!res.ok) throw new Error();
             const j = await res.json();
             const arr = Array.isArray(j)
@@ -113,7 +117,9 @@ export default function ToursContent() {
     };
     const fetchAllGenresWithSub = async () => {
         try {
-            const res = await fetch(`${API_BASE_URL}/genres-with-subgenres`);
+            const res = await fetch(`${API_BASE_URL}/genres-with-subgenres`, {
+                credentials: 'include',
+            });
             if (!res.ok) throw new Error();
             const j = await res.json();
             setAllGenres(j.genres || []);
@@ -124,7 +130,9 @@ export default function ToursContent() {
 
     const fetchAllVenues = async () => {
         try {
-            const res = await fetch(`${API_BASE_URL}/venues`);
+            const res = await fetch(`${API_BASE_URL}/venues`, {
+                credentials: 'include',
+            });
             if (!res.ok) throw new Error();
             const j = await res.json();
             setAllVenues(j.venues || []);
@@ -141,7 +149,7 @@ export default function ToursContent() {
         );
         ids.forEach((id) => {
             if (eventTickets[id] !== undefined) return;
-            fetch(`${API_BASE_URL}/event-capacities/${id}`)
+            fetch(`${API_BASE_URL}/event-capacities/${id}`, { credentials: 'include' })
                 .then((r) => (r.ok ? r.json() : null))
                 .then((d) => {
                     const sold = (d?.categories || []).reduce(
@@ -214,8 +222,8 @@ export default function ToursContent() {
         });
         try {
             const [ra, rg] = await Promise.all([
-                fetch(`${API_BASE_URL}/tour-artists?tourId=${tour.id}`),
-                fetch(`${API_BASE_URL}/tour-genres?tourId=${tour.id}`)
+                fetch(`${API_BASE_URL}/tour-artists?tourId=${tour.id}`, { credentials: 'include' }),
+                fetch(`${API_BASE_URL}/tour-genres?tourId=${tour.id}`, { credentials: 'include' })
             ]);
             const [ja, jg] = await Promise.all([ra.json(), rg.json()]);
             setTourArtists(ja.artists || []);
@@ -227,7 +235,7 @@ export default function ToursContent() {
         // Event-Details laden
         try {
             const promises = (tour.events || []).map((ev) =>
-                fetch(`${API_BASE_URL}/event-details/${ev.id}`).then((r) =>
+                fetch(`${API_BASE_URL}/event-details/${ev.id}`, { credentials: 'include' }).then((r) =>
                     r.ok ? r.json() : null
                 )
             );
@@ -313,6 +321,7 @@ export default function ToursContent() {
             const r = await fetch(`${API_BASE_URL}/tours/${editedData.id}`, {
                 method: 'PUT',
                 body: fd,
+                credentials: 'include',
             });
             if (!r.ok) throw new Error();
 
@@ -320,7 +329,8 @@ export default function ToursContent() {
                 fetch(`${API_BASE_URL}/events/${eid}`, {
                     method: 'PUT',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(data)
+                    body: JSON.stringify(data),
+                    credentials: 'include'
                 })
             );
             await Promise.all(eventPromises);
@@ -333,7 +343,7 @@ export default function ToursContent() {
 
     const handleDelete = async (id) => {
         try {
-            const r = await fetch(`${API_BASE_URL}/tours/${id}`, { method: 'DELETE' });
+            const r = await fetch(`${API_BASE_URL}/tours/${id}`, { method: 'DELETE', credentials: 'include' });
             if (!r.ok) throw new Error();
             setConfirmDeleteId(null);
             fetchTours();
@@ -346,7 +356,7 @@ export default function ToursContent() {
         e.stopPropagation();
         if (!confirm('Event wirklich löschen?')) return;
         try {
-            const r = await fetch(`${API_BASE_URL}/events/${eventId}`, { method: 'DELETE' });
+            const r = await fetch(`${API_BASE_URL}/events/${eventId}`, { method: 'DELETE', credentials: 'include' });
             if (!r.ok) throw new Error();
             fetchTours();
         } catch {

--- a/eventim-disability-integration/src/pages/admin/venues/areas/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/areas/create.jsx
@@ -37,7 +37,8 @@ export default function AreaCreation() {
             const res = await fetch('http://localhost:4000/create-area', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(formData)
+                body: JSON.stringify(formData),
+                credentials: 'include',
             });
             const data = await res.json();
             if (res.ok) {

--- a/eventim-disability-integration/src/pages/admin/venues/create.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/create.jsx
@@ -30,10 +30,10 @@ export default function VenueCreation() {
     });
 
     useEffect(() => {
-        fetch('http://localhost:4000/cities')
+        fetch('http://localhost:4000/cities', { credentials: 'include' })
             .then((r) => r.json())
             .then((d) => setCities(d.cities));
-        fetch('http://localhost:4000/areas')
+        fetch('http://localhost:4000/areas', { credentials: 'include' })
             .then((r) => r.json())
             .then((d) => setAreas(d.areas));
     }, []);
@@ -104,6 +104,7 @@ export default function VenueCreation() {
             const res = await fetch('http://localhost:4000/create-venue', {
                 method: 'POST',
                 body: fd,
+                credentials: 'include',
             });
             const data = await res.json();
 

--- a/eventim-disability-integration/src/pages/admin/venues/index.jsx
+++ b/eventim-disability-integration/src/pages/admin/venues/index.jsx
@@ -44,7 +44,7 @@ export default function VenuesContent() {
 
     const fetchVenues = async () => {
         try {
-            const res = await fetch('http://localhost:4000/venues-detailed');
+            const res = await fetch('http://localhost:4000/venues-detailed', { credentials: 'include' });
             const json = await res.json();
             const arr = Array.isArray(json.venues) ? json.venues : [];
             setVenues(arr);
@@ -58,7 +58,7 @@ export default function VenuesContent() {
 
     const fetchCities = async () => {
         try {
-            const res = await fetch('http://localhost:4000/cities');
+            const res = await fetch('http://localhost:4000/cities', { credentials: 'include' });
             const json = await res.json();
             setCities(json.cities || []);
         } catch (err) {
@@ -68,7 +68,7 @@ export default function VenuesContent() {
 
     const fetchAreas = async () => {
         try {
-            const res = await fetch('http://localhost:4000/areas');
+            const res = await fetch('http://localhost:4000/areas', { credentials: 'include' });
             const json = await res.json();
             setAreas(json.areas || []);
         } catch (err) {
@@ -88,7 +88,7 @@ export default function VenuesContent() {
             existingImageId: venue.venue_image || null,
         });
         try {
-            const res = await fetch(`http://localhost:4000/venue-areas?venueId=${venue.id}`);
+            const res = await fetch(`http://localhost:4000/venue-areas?venueId=${venue.id}`, { credentials: 'include' });
             const json = await res.json();
             const arr = Array.isArray(json.venueAreas) ? json.venueAreas : [];
             setVenueAreas(arr.map((va) => ({ id: va.id, areaId: va.area_id, maxCapacity: va.max_capacity })));
@@ -147,6 +147,7 @@ export default function VenuesContent() {
             const response = await fetch(`http://localhost:4000/venues/${editedData.id}`, {
                 method: 'PUT',
                 body: fd,
+                credentials: 'include',
             });
             if (!response.ok) {
                 const d = await response.json().catch(() => ({}));
@@ -165,6 +166,7 @@ export default function VenuesContent() {
         try {
             const response = await fetch(`http://localhost:4000/venues/${id}`, {
                 method: 'DELETE',
+                credentials: 'include',
             });
             if (!response.ok) {
                 const errorData = await response.json().catch(() => ({}));

--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/[event]/index.jsx
@@ -92,7 +92,9 @@ export default function EventPage() {
         if (!artist || !tour || !event) return;
         const load = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/event-details/${event}`);
+                const res = await fetch(`${API_BASE_URL}/event-details/${event}`, {
+                    credentials: 'include',
+                });
                 if (!res.ok) throw new Error('Fetch failed');
                 const data = await res.json();
 

--- a/eventim-disability-integration/src/pages/artists/[artist]/[tour]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/[tour]/index.jsx
@@ -27,7 +27,9 @@ export default function TourEventsPage() {
         if (!tour) return;
         const load = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/tour-details/${tour}`);
+                const res = await fetch(`${API_BASE_URL}/tour-details/${tour}`, {
+                    credentials: 'include',
+                });
                 if (!res.ok) throw new Error();
                 const data = await res.json();
                 setTourData(data.tour);
@@ -48,7 +50,9 @@ export default function TourEventsPage() {
             const map = {};
             for (const ev of events) {
                 try {
-                    const res = await fetch(`${API_BASE_URL}/event-capacities/${ev.id}`);
+                    const res = await fetch(`${API_BASE_URL}/event-capacities/${ev.id}`, {
+                        credentials: 'include',
+                    });
                     if (!res.ok) continue;
                     const data = await res.json();
                     map[ev.id] = data;

--- a/eventim-disability-integration/src/pages/artists/[artist]/index.jsx
+++ b/eventim-disability-integration/src/pages/artists/[artist]/index.jsx
@@ -39,7 +39,9 @@ export default function ArtistPage() {
         if (!artist) return;
         const loadArtist = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/artist-details/${artist}`);
+                const res = await fetch(`${API_BASE_URL}/artist-details/${artist}`, {
+                    credentials: 'include',
+                });
                 if (!res.ok) throw new Error();
                 const data = await res.json();
                 setArtistData(data.artist);
@@ -54,7 +56,9 @@ export default function ArtistPage() {
     useEffect(() => {
         const fetchTours = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/tours-detailed`);
+                const res = await fetch(`${API_BASE_URL}/tours-detailed`, {
+                    credentials: 'include',
+                });
                 if (!res.ok) throw new Error();
                 const json = await res.json();
                 const arr = Array.isArray(json.tours) ? json.tours : [];

--- a/eventim-disability-integration/src/pages/genres/[genre]/[subgenre]/index.jsx
+++ b/eventim-disability-integration/src/pages/genres/[genre]/[subgenre]/index.jsx
@@ -17,7 +17,9 @@ export default function SubgenreEventsPage() {
         if (!genre || !subgenre) return;
         const load = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/genres-with-subgenres`);
+                const res = await fetch(`${API_BASE_URL}/genres-with-subgenres`, {
+                    credentials: 'include',
+                });
                 if (!res.ok) throw new Error();
                 const data = await res.json();
                 const g = (data.genres || []).find((gr) => gr.id === genre);
@@ -26,7 +28,9 @@ export default function SubgenreEventsPage() {
                 if (!sg) throw new Error();
                 setSubgenreData({ id: sg.id, name: sg.name, genreName: g.name });
 
-                const toursRes = await fetch(`${API_BASE_URL}/tours-detailed`);
+                const toursRes = await fetch(`${API_BASE_URL}/tours-detailed`, {
+                    credentials: 'include',
+                });
                 if (!toursRes.ok) throw new Error();
                 const toursJson = await toursRes.json();
                 const tours = Array.isArray(toursJson.tours) ? toursJson.tours : [];
@@ -63,7 +67,9 @@ export default function SubgenreEventsPage() {
             const map = {};
             for (const ev of events) {
                 try {
-                    const res = await fetch(`${API_BASE_URL}/event-capacities/${ev.id}`);
+                    const res = await fetch(`${API_BASE_URL}/event-capacities/${ev.id}`, {
+                        credentials: 'include',
+                    });
                     if (!res.ok) continue;
                     const data = await res.json();
                     map[ev.id] = data;

--- a/eventim-disability-integration/src/pages/genres/[genre]/index.jsx
+++ b/eventim-disability-integration/src/pages/genres/[genre]/index.jsx
@@ -30,7 +30,9 @@ export default function GenrePage() {
         if (!genre) return;
         const loadGenre = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/genres-with-subgenres`);
+                const res = await fetch(`${API_BASE_URL}/genres-with-subgenres`, {
+                    credentials: 'include',
+                });
                 if (!res.ok) throw new Error();
                 const data = await res.json();
                 const g = (data.genres || []).find((gr) => gr.id === genre);
@@ -51,7 +53,9 @@ export default function GenrePage() {
     useEffect(() => {
         const fetchTours = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/tours-detailed`);
+                const res = await fetch(`${API_BASE_URL}/tours-detailed`, {
+                    credentials: 'include',
+                });
                 if (!res.ok) throw new Error();
                 const json = await res.json();
                 setTours(Array.isArray(json.tours) ? json.tours : []);

--- a/eventim-disability-integration/src/pages/index.jsx
+++ b/eventim-disability-integration/src/pages/index.jsx
@@ -14,7 +14,9 @@ export default function HomePage() {
     useEffect(() => {
         async function fetchTours() {
             try {
-                const res = await fetch("http://localhost:4000/tours-with-images");
+                const res = await fetch("http://localhost:4000/tours-with-images", {
+                    credentials: "include",
+                });
                 if (!res.ok) throw new Error("Failed to load tours");
                 const body = await res.json();
                 setTours(body.tours);
@@ -30,7 +32,9 @@ export default function HomePage() {
     useEffect(() => {
         async function fetchArtists() {
             try {
-                const res = await fetch("http://localhost:4000/artists-with-images");
+                const res = await fetch("http://localhost:4000/artists-with-images", {
+                    credentials: "include",
+                });
                 if (!res.ok) throw new Error("Failed to load artists");
                 const body = await res.json();
                 setArtists(body.artists);

--- a/eventim-disability-integration/src/pages/locations/[city]/[venue]/index.jsx
+++ b/eventim-disability-integration/src/pages/locations/[city]/[venue]/index.jsx
@@ -17,7 +17,9 @@ export default function VenueEventsPage() {
         if (!city || !venue) return;
         const load = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/cities-with-venues`);
+                const res = await fetch(`${API_BASE_URL}/cities-with-venues`, {
+                    credentials: 'include',
+                });
                 if (!res.ok) throw new Error();
                 const data = await res.json();
                 const c = (data.cities || []).find((ci) => ci.id === city);
@@ -25,7 +27,9 @@ export default function VenueEventsPage() {
                 if (!c || !v) throw new Error();
                 setVenueData({ id: v.id, name: v.name, cityName: c.name });
 
-                const toursRes = await fetch(`${API_BASE_URL}/tours-detailed`);
+                const toursRes = await fetch(`${API_BASE_URL}/tours-detailed`, {
+                    credentials: 'include',
+                });
                 if (!toursRes.ok) throw new Error();
                 const toursJson = await toursRes.json();
                 const tours = Array.isArray(toursJson.tours) ? toursJson.tours : [];
@@ -59,7 +63,9 @@ export default function VenueEventsPage() {
             const map = {};
             for (const ev of events) {
                 try {
-                    const res = await fetch(`${API_BASE_URL}/event-capacities/${ev.id}`);
+                    const res = await fetch(`${API_BASE_URL}/event-capacities/${ev.id}`, {
+                        credentials: 'include',
+                    });
                     if (!res.ok) continue;
                     const data = await res.json();
                     map[ev.id] = data;

--- a/eventim-disability-integration/src/pages/locations/[city]/index.jsx
+++ b/eventim-disability-integration/src/pages/locations/[city]/index.jsx
@@ -27,7 +27,9 @@ export default function CityPage() {
         if (!city) return;
         const loadCity = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/cities-with-venues`);
+                const res = await fetch(`${API_BASE_URL}/cities-with-venues`, {
+                    credentials: 'include',
+                });
                 if (!res.ok) throw new Error();
                 const data = await res.json();
                 const c = (data.cities || []).find((ci) => ci.id === city);
@@ -48,7 +50,9 @@ export default function CityPage() {
     useEffect(() => {
         const fetchTours = async () => {
             try {
-                const res = await fetch(`${API_BASE_URL}/tours-detailed`);
+                const res = await fetch(`${API_BASE_URL}/tours-detailed`, {
+                    credentials: 'include',
+                });
                 if (!res.ok) throw new Error();
                 const json = await res.json();
                 setTours(Array.isArray(json.tours) ? json.tours : []);

--- a/eventim-disability-integration/src/pages/login.jsx
+++ b/eventim-disability-integration/src/pages/login.jsx
@@ -38,7 +38,8 @@ export default function LoginPage() {
     const checkEmailExists = async (email) => {
         try {
             const res = await fetch(
-                `http://localhost:4000/email-exists?email=${encodeURIComponent(email)}`
+                `http://localhost:4000/email-exists?email=${encodeURIComponent(email)}`,
+                { credentials: 'include' }
             );
             const data = await res.json();
             return data.exists;

--- a/eventim-disability-integration/src/pages/profile/index.jsx
+++ b/eventim-disability-integration/src/pages/profile/index.jsx
@@ -162,7 +162,9 @@ export default function ProfilePage() {
             const query = marks && marks.length > 0
                 ? `?marks=${encodeURIComponent(marks.join(','))}`
                 : '';
-            const res = await fetch(`${API_BASE_URL}/tours-detailed${query}`);
+            const res = await fetch(`${API_BASE_URL}/tours-detailed${query}`, {
+                credentials: 'include',
+            });
             if (res.ok) {
                 const data = await res.json();
                 setTours(Array.isArray(data.tours) ? data.tours : []);
@@ -231,7 +233,9 @@ export default function ProfilePage() {
 
     const fetchMarks = async () => {
         try {
-            const res = await fetch(`${API_BASE_URL}/disability-marks`);
+            const res = await fetch(`${API_BASE_URL}/disability-marks`, {
+                credentials: 'include',
+            });
             if (res.ok) {
                 const json = await res.json();
                 setMarks(Array.isArray(json.marks) ? json.marks : []);

--- a/eventim-disability-integration/src/pages/registration.jsx
+++ b/eventim-disability-integration/src/pages/registration.jsx
@@ -68,7 +68,9 @@ export default function Registration() {
     useEffect(() => {
         async function fetchMarks() {
             try {
-                const res = await fetch('http://localhost:4000/disability-marks');
+                const res = await fetch('http://localhost:4000/disability-marks', {
+                    credentials: 'include',
+                });
                 if (!res.ok) throw new Error('Failed to load disability marks');
                 const json = await res.json();
                 // Expecting json.marks to be an array of { mark_code, description, area_name }
@@ -211,6 +213,7 @@ export default function Registration() {
             const response = await fetch('http://localhost:4000/register-user', {
                 method: 'POST',
                 body: payload,
+                credentials: 'include',
             });
             const data = await response.json();
 

--- a/eventim-disability-integration/src/pages/service/account-management.jsx
+++ b/eventim-disability-integration/src/pages/service/account-management.jsx
@@ -21,7 +21,9 @@ export default function UserOverview() {
 
     const fetchRoles = async () => {
         try {
-            const res = await fetch(`${API_BASE_URL}/user-roles`);
+            const res = await fetch(`${API_BASE_URL}/user-roles`, {
+                credentials: 'include',
+            });
             if (res.ok) {
                 const js = await res.json();
                 setRoles(Array.isArray(js.roles) ? js.roles : []);
@@ -37,7 +39,9 @@ export default function UserOverview() {
 
     const fetchUsers = async (roleId) => {
         try {
-            const res = await fetch(`${API_BASE_URL}/users?roleId=${roleId}`);
+            const res = await fetch(`${API_BASE_URL}/users?roleId=${roleId}`, {
+                credentials: 'include',
+            });
             if (res.ok) {
                 const js = await res.json();
                 setUsersByRole(prev => ({ ...prev, [roleId]: js.users || [] }));
@@ -50,8 +54,8 @@ export default function UserOverview() {
     const openUser = async (userId) => {
         try {
             const [uRes, oRes] = await Promise.all([
-                fetch(`${API_BASE_URL}/users/${userId}`),
-                fetch(`${API_BASE_URL}/users/${userId}/orders`)
+                fetch(`${API_BASE_URL}/users/${userId}`, { credentials: 'include' }),
+                fetch(`${API_BASE_URL}/users/${userId}/orders`, { credentials: 'include' })
             ]);
             if (uRes.ok) {
                 const uj = await uRes.json();

--- a/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
+++ b/eventim-disability-integration/src/pages/service/compensation-for-disadvantages-requests.jsx
@@ -20,7 +20,9 @@ export default function CompensationRequests() {
 
     const fetchPending = async () => {
         try {
-            const r = await fetch(`${API_BASE_URL}/pending-disability-requests`);
+            const r = await fetch(`${API_BASE_URL}/pending-disability-requests`, {
+                credentials: 'include',
+            });
             if (r.ok) {
                 const js = await r.json();
                 setRequests(Array.isArray(js.requests) ? js.requests : []);
@@ -32,7 +34,9 @@ export default function CompensationRequests() {
 
     const fetchAccepted = async () => {
         try {
-            const r = await fetch(`${API_BASE_URL}/accepted-disability-requests`);
+            const r = await fetch(`${API_BASE_URL}/accepted-disability-requests`, {
+                credentials: 'include',
+            });
             if (r.ok) {
                 const js = await r.json();
                 setAcceptedRequests(Array.isArray(js.requests) ? js.requests : []);
@@ -49,7 +53,9 @@ export default function CompensationRequests() {
 
     const loadDetail = async (req) => {
         try {
-            const r = await fetch(`${API_BASE_URL}/users/${req.user_id}/disability`);
+            const r = await fetch(`${API_BASE_URL}/users/${req.user_id}/disability`, {
+                credentials: 'include',
+            });
             if (!r.ok) return;
             const js = await r.json();
             setDetail(js.disabilityData || null);
@@ -61,14 +67,18 @@ export default function CompensationRequests() {
             });
 
             if (js.disabilityData?.disability_card_image_front) {
-                const fr = await fetch(`${API_BASE_URL}/image/${js.disabilityData.disability_card_image_front}`);
+                const fr = await fetch(`${API_BASE_URL}/image/${js.disabilityData.disability_card_image_front}`, {
+                    credentials: 'include',
+                });
                 if (fr.ok) {
                     const blob = await fr.blob();
                     setImgFrontUrl(URL.createObjectURL(blob));
                 }
             }
             if (js.disabilityData?.disability_card_image_back) {
-                const br = await fetch(`${API_BASE_URL}/image/${js.disabilityData.disability_card_image_back}`);
+                const br = await fetch(`${API_BASE_URL}/image/${js.disabilityData.disability_card_image_back}`, {
+                    credentials: 'include',
+                });
                 if (br.ok) {
                     const blob = await br.blob();
                     setImgBackUrl(URL.createObjectURL(blob));
@@ -91,7 +101,10 @@ export default function CompensationRequests() {
     const acceptRequest = async () => {
         if (!selectedUser) return;
         try {
-            await fetch(`${API_BASE_URL}/disability-requests/${selectedUser.user_id}/accept`, { method: 'POST' });
+            await fetch(`${API_BASE_URL}/disability-requests/${selectedUser.user_id}/accept`, {
+                method: 'POST',
+                credentials: 'include',
+            });
         } catch (err) {
             console.error('Error accepting request:', err);
         }
@@ -102,7 +115,10 @@ export default function CompensationRequests() {
     const declineRequest = async () => {
         if (!selectedUser) return;
         try {
-            await fetch(`${API_BASE_URL}/disability-requests/${selectedUser.user_id}/decline`, { method: 'POST' });
+            await fetch(`${API_BASE_URL}/disability-requests/${selectedUser.user_id}/decline`, {
+                method: 'POST',
+                credentials: 'include',
+            });
         } catch (err) {
             console.error('Error declining request:', err);
         }


### PR DESCRIPTION
## Summary
- ensure session cookie is sent in all client fetch calls by adding `credentials: 'include'`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68833155fe388330ad3a5df84e88ed5a