### PR TITLE
Fix checkout session restoration

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -4117,9 +4117,28 @@ app.get('/checkout-items', async (req, res) => {
         return res.status(401).json({ message: 'Not logged in' });
     }
 
-    const checkoutSession = req.session.checkout;
+    let checkoutSession = req.session.checkout;
     if (!checkoutSession || Date.now() - checkoutSession.startedAt > 15 * 60 * 1000) {
-        return res.status(404).json({ message: 'No active checkout' });
+        // try to restore from DB when the session information is missing
+        try {
+            const { rows } = await client.query(
+                'SELECT id, created_at FROM checkouts WHERE user_id = $1',
+                [userId]
+            );
+            if (rows.length === 0) {
+                req.session.checkout = null;
+                return res.status(404).json({ message: 'No active checkout' });
+            }
+            const { id, created_at } = rows[0];
+            checkoutSession = req.session.checkout = {
+                id,
+                startedAt: new Date(created_at).getTime(),
+                shippingInfo: null,
+            };
+        } catch (err) {
+            console.error('Error restoring checkout session:', err);
+            return res.status(500).json({ message: 'Server error' });
+        }
     }
 
     try {

--- a/eventim-disability-integration/src/components/nav-bar.jsx
+++ b/eventim-disability-integration/src/components/nav-bar.jsx
@@ -3,11 +3,13 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import Image from 'next/image';
+import { useRouter } from 'next/router';
 import { useAuth } from '../hooks/useAuth';
 import { useCart } from '../hooks/useCart';
 import { API_BASE_URL } from '../config';
 
 export default function NavBar() {
+    const router = useRouter();
     const [openDropdown, setOpenDropdown] = useState(null);
     const [genres, setGenres] = useState([]);
     const [cities, setCities] = useState([]);
@@ -336,7 +338,7 @@ export default function NavBar() {
                                                         credentials: 'include',
                                                     });
                                                     if (res.ok) {
-                                                        window.location.href = '/checkout/shopping-cart';
+                                                        router.push('/checkout/shopping-cart');
                                                     } else if (res.status === 409) {
                                                         setShowCheckoutModal(true);
                                                     } else {


### PR DESCRIPTION
## Summary
- restore checkout session from DB if session data missing
- use Next.js router for checkout navigation

## Testing
- `npm install`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888738b50d88330a5a2d7d25b0f7ac9