### PR TITLE
Fix checkout cookie handling

### DIFF
--- a/eventim-disability-integration/src/pages/checkout/payment.jsx
+++ b/eventim-disability-integration/src/pages/checkout/payment.jsx
@@ -6,13 +6,19 @@ import { useRouter } from "next/router";
 import { API_BASE_URL } from "../../config";
 import CheckoutExpiredModal from "../../components/CheckoutExpiredModal";
 
-export async function getServerSideProps({ req }) {
+export async function getServerSideProps({ req, res }) {
     const cookie = req.headers.cookie || "";
     try {
-        const res = await fetch(`${API_BASE_URL}/checkout-items`, {
+        const backendRes = await fetch(`${API_BASE_URL}/checkout-items`, {
             headers: { cookie },
         });
-        if (res.status !== 200) {
+
+        const setCookie = backendRes.headers.get("set-cookie");
+        if (setCookie) {
+            res.setHeader("set-cookie", setCookie);
+        }
+
+        if (backendRes.status !== 200) {
             return { redirect: { destination: "/", permanent: false } };
         }
     } catch {

--- a/eventim-disability-integration/src/pages/checkout/shopping-cart.jsx
+++ b/eventim-disability-integration/src/pages/checkout/shopping-cart.jsx
@@ -6,16 +6,25 @@ import { useRouter } from 'next/router';
 import { API_BASE_URL } from '../../config'; // adjust path if needed
 import CheckoutExpiredModal from '../../components/CheckoutExpiredModal';
 
-export async function getServerSideProps({ req }) {
+export async function getServerSideProps({ req, res }) {
     const cookie = req.headers.cookie || '';
     try {
-        const res = await fetch(`${API_BASE_URL}/checkout-items`, { headers: { cookie } });
-        if (res.status !== 200) {
+        const backendRes = await fetch(`${API_BASE_URL}/checkout-items`, {
+            headers: { cookie },
+        });
+
+        const setCookie = backendRes.headers.get('set-cookie');
+        if (setCookie) {
+            res.setHeader('set-cookie', setCookie);
+        }
+
+        if (backendRes.status !== 200) {
             return { redirect: { destination: '/', permanent: false } };
         }
     } catch {
         return { redirect: { destination: '/', permanent: false } };
     }
+
     return { props: {} };
 }
 


### PR DESCRIPTION
## Summary
- forward `set-cookie` headers on checkout pages so browser keeps the same session

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888738b50d88330a5a2d7d25b0f7ac9