### PR TITLE
Fix checkout session persistence

### DIFF
--- a/eventim-disability-integration/server/server.js
+++ b/eventim-disability-integration/server/server.js
@@ -72,6 +72,36 @@ function restoreSession(req, res, next) {
 
 app.use(restoreSession);
 
+async function restoreCheckout(req, res, next) {
+    if (!req.session.userId || req.session.checkout) return next();
+    const checkoutId = req.cookies && req.cookies.checkoutId;
+    if (!checkoutId) return next();
+    try {
+        const { rows } = await client.query(
+            'SELECT created_at FROM checkouts WHERE id = $1 AND user_id = $2',
+            [checkoutId, req.session.userId]
+        );
+        if (!rows.length) {
+            res.clearCookie('checkoutId');
+            return next();
+        }
+        const created = rows[0].created_at;
+        const started = new Date(created).getTime();
+        if (Date.now() - started > 15 * 60 * 1000) {
+            await client.query('DELETE FROM checkout_items WHERE checkout_id = $1', [checkoutId]);
+            await client.query('DELETE FROM checkouts WHERE id = $1', [checkoutId]);
+            res.clearCookie('checkoutId');
+            return next();
+        }
+        req.session.checkout = { id: checkoutId, startedAt: started, shippingInfo: null };
+    } catch (err) {
+        console.error('Error restoring checkout:', err);
+    }
+    next();
+}
+
+app.use(restoreCheckout);
+
 // Serve /uploads as static
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 
@@ -831,6 +861,7 @@ app.post('/checkout-shipping', (req, res) => {
 
     if (Date.now() - req.session.checkout.startedAt > 15 * 60 * 1000) {
         req.session.checkout = null;
+        res.clearCookie('checkoutId');
         return res.status(400).json({ message: 'Checkout expired' });
     }
 
@@ -850,6 +881,7 @@ app.get('/checkout-shipping', (req, res) => {
 
     if (Date.now() - req.session.checkout.startedAt > 15 * 60 * 1000) {
         req.session.checkout = null;
+        res.clearCookie('checkoutId');
         return res.status(404).json({ message: 'Checkout expired' });
     }
 
@@ -867,6 +899,7 @@ app.post('/checkout-payment', (req, res) => {
 
     if (Date.now() - req.session.checkout.startedAt > 15 * 60 * 1000) {
         req.session.checkout = null;
+        res.clearCookie('checkoutId');
         return res.status(400).json({ message: 'Checkout expired' });
     }
 
@@ -886,6 +919,7 @@ app.get('/checkout-payment', (req, res) => {
 
     if (Date.now() - req.session.checkout.startedAt > 15 * 60 * 1000) {
         req.session.checkout = null;
+        res.clearCookie('checkoutId');
         return res.status(404).json({ message: 'Checkout expired' });
     }
 
@@ -4101,6 +4135,13 @@ app.post('/checkout', async (req, res) => {
             shippingInfo: null,
         };
 
+        res.cookie('checkoutId', checkoutId, {
+            httpOnly: true,
+            secure: false,
+            sameSite: 'lax',
+            maxAge: 15 * 60 * 1000,
+        });
+
         return res.status(201).json({ checkoutId });
     } catch (err) {
         await client.query('ROLLBACK');
@@ -4119,6 +4160,8 @@ app.get('/checkout-items', async (req, res) => {
 
     const checkoutSession = req.session.checkout;
     if (!checkoutSession || Date.now() - checkoutSession.startedAt > 15 * 60 * 1000) {
+        req.session.checkout = null;
+        res.clearCookie('checkoutId');
         return res.status(404).json({ message: 'No active checkout' });
     }
 
@@ -4129,6 +4172,7 @@ app.get('/checkout-items', async (req, res) => {
             [userId]
         );
         if (coRows.length === 0) {
+            res.clearCookie('checkoutId');
             return res.status(404).json({ message: 'No active checkout' });
         }
         const { id: checkoutId, created_at } = coRows[0];
@@ -4192,6 +4236,7 @@ app.delete('/checkout', async (req, res) => {
         await client.query('DELETE FROM checkouts WHERE id = $1', [checkoutId]);
         await client.query('COMMIT');
         req.session.checkout = null;
+        res.clearCookie('checkoutId');
 
         return res.json({ message: 'Checkout cleared' });
     } catch (err) {
@@ -4235,6 +4280,7 @@ app.delete('/checkout-items/:id', async (req, res) => {
         if (remaining.length === 0) {
             await client.query('DELETE FROM checkouts WHERE user_id = $1', [userId]);
             req.session.checkout = null;
+            res.clearCookie('checkoutId');
         }
 
         return res.json({ message: 'Item removed' });
@@ -4251,6 +4297,7 @@ app.post('/orders', async (req, res) => {
     const sessionCheckout = req.session.checkout;
     if (!sessionCheckout || Date.now() - sessionCheckout.startedAt > 15 * 60 * 1000) {
         req.session.checkout = null;
+        res.clearCookie('checkoutId');
         return res.status(400).json({ message: 'Checkout expired' });
     }
     if (!sessionCheckout.shippingInfo || !sessionCheckout.paymentMethod) {
@@ -4385,6 +4432,7 @@ app.post('/orders', async (req, res) => {
         await client.query('COMMIT');
 
         req.session.checkout = null;
+        res.clearCookie('checkoutId');
         return res.status(201).json({ orderId });
     } catch (err) {
         await client.query('ROLLBACK');


### PR DESCRIPTION
## Summary
- restore checkout from cookie if session lost
- store `checkoutId` in cookie when checkout is created
- clear `checkoutId` cookie when checkout ends or expires

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6888738b50d88330a5a2d7d25b0f7ac9